### PR TITLE
Add LLM-generated HTML poster pipeline (Puppeteer rendering) for XHS & WeChat sharing

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -21,6 +21,7 @@
     "hono": "^4.6.0",
     "@hono/node-server": "^1.13.0",
     "@hono/zod-validator": "^0.4.0",
+    "@sparticuz/chromium": "^119.0.0",
     "drizzle-orm": "^0.36.0",
     "postgres": "^3.4.0",
     "zod": "^3.25.0",
@@ -28,6 +29,7 @@
     "ai": "^4.0.0",
     "@ai-sdk/openai": "^1.0.0",
     "drizzle-zod": "^0.5.0",
+    "puppeteer-core": "^21.6.0",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/apps/backend/src/controllers/poster.controller.ts
+++ b/apps/backend/src/controllers/poster.controller.ts
@@ -1,0 +1,82 @@
+import { Hono } from "hono";
+import { zValidator } from "@hono/zod-validator";
+import { z } from "zod";
+import { v4 as uuidv4 } from "uuid";
+import { resolvePosterStyle, type PosterRatio } from "../services/HtmlPosterService";
+import { POSTER_STYLE_KEYS } from "../services/PosterStylePrompts";
+import {
+  htmlPosterService,
+  posterRenderService,
+  posterStorageService,
+} from "../services/posterServices";
+
+const app = new Hono();
+
+const generatePosterSchema = z.object({
+  caption: z.string().min(1),
+  style: z
+    .union([z.number().int().min(0).max(4), z.enum(POSTER_STYLE_KEYS)])
+    .optional(),
+  ratio: z.enum(["3:4", "1:1", "4:3"]).optional(),
+  saveOnServer: z.boolean().optional(),
+});
+
+const isWeChatBrowser = (userAgent: string): boolean =>
+  /MicroMessenger/i.test(userAgent);
+
+app.post(
+  "/html",
+  zValidator("json", generatePosterSchema),
+  async (c) => {
+    const { caption, style, ratio, saveOnServer } = c.req.valid("json");
+    const userAgent = c.req.header("user-agent") ?? "";
+    const shouldSave = saveOnServer ?? isWeChatBrowser(userAgent);
+    const posterRatio: PosterRatio = ratio ?? "3:4";
+
+    const resolvedStyle = resolvePosterStyle(style);
+
+    const generatedPoster = await htmlPosterService.generatePosterHtml({
+      caption,
+      style: resolvedStyle,
+      ratio: posterRatio,
+      saveOnServer: shouldSave,
+    });
+
+    const imageBuffer = await posterRenderService.renderHtmlToPng(
+      generatedPoster.html,
+      generatedPoster.dimensions,
+    );
+
+    if (shouldSave) {
+      const filename = `${uuidv4()}.png`;
+      await posterStorageService.savePoster(imageBuffer, filename);
+      const origin = new URL(c.req.url).origin;
+      const posterUrl = posterStorageService.getPosterUrl(filename, origin);
+      return c.json({ posterUrl, saved: true });
+    }
+
+    const base64Image = imageBuffer.toString("base64");
+    const posterUrl = `data:image/png;base64,${base64Image}`;
+    return c.json({ posterUrl, saved: false });
+  },
+);
+
+app.get("/download/:filename", async (c) => {
+  const filename = c.req.param("filename");
+  if (!filename) {
+    return c.json({ error: "filename is required" }, 400);
+  }
+
+  const posterBuffer = await posterStorageService.readPoster(filename);
+  if (!posterBuffer) {
+    return c.json({ error: "File not found" }, 404);
+  }
+
+  return c.body(posterBuffer, 200, {
+    "Content-Type": "image/png",
+    "Content-Disposition": `inline; filename="${filename}"`,
+    "Cache-Control": "public, max-age=31536000",
+  });
+});
+
+export const posterRoute = app;

--- a/apps/backend/src/services/HtmlPosterService.ts
+++ b/apps/backend/src/services/HtmlPosterService.ts
@@ -1,0 +1,242 @@
+import { generateObject } from "ai";
+import { createOpenAI, openai } from "@ai-sdk/openai";
+import { z } from "zod";
+import { env } from "../lib/env";
+import {
+  POSTER_STYLE_PROMPTS,
+  POSTER_STYLE_KEYS,
+  PosterStyleKey,
+} from "./PosterStylePrompts";
+
+export type PosterRatio = "3:4" | "1:1" | "4:3";
+
+export interface PosterGenerationRequest {
+  caption: string;
+  style: PosterStyleKey;
+  ratio: PosterRatio;
+  saveOnServer?: boolean;
+  includeAiGraphics?: boolean;
+}
+
+export interface PosterDimensions {
+  width: number;
+  height: number;
+}
+
+export interface GeneratedPoster {
+  html: string;
+  dimensions: PosterDimensions;
+}
+
+interface ContentMetadata {
+  type: "event" | "lifestyle" | "knowledge" | "emotional" | "business";
+  length: number;
+  sentiment: "positive" | "neutral" | "excited" | "calm";
+  keywords: string[];
+  hasTime: boolean;
+  hasLocation: boolean;
+  hasEmoji: boolean;
+}
+
+const DIMENSIONS_BY_RATIO: Record<PosterRatio, PosterDimensions> = {
+  "3:4": { width: 1080, height: 1440 },
+  "1:1": { width: 1080, height: 1080 },
+  "4:3": { width: 1440, height: 1080 },
+};
+
+const EMOJI_REGEX = /\p{Extended_Pictographic}/u;
+
+export class HtmlPosterService {
+  private client: typeof openai;
+
+  constructor() {
+    if (env.LLM_BASE_URL) {
+      this.client = createOpenAI({
+        apiKey: env.LLM_API_KEY,
+        baseURL: env.LLM_BASE_URL,
+      });
+    } else {
+      this.client = openai;
+    }
+  }
+
+  async generatePosterHtml(
+    request: PosterGenerationRequest,
+  ): Promise<GeneratedPoster> {
+    const dimensions = DIMENSIONS_BY_RATIO[request.ratio];
+    const metadata = analyzeContent(request.caption);
+    const prompt = buildPosterPrompt(request, metadata, dimensions);
+
+    const { object } = await generateObject({
+      model: this.client(env.LLM_DEFAULT_MODEL),
+      schema: z.object({
+        html: z.string().min(1),
+      }),
+      prompt,
+      temperature: 0.6,
+    });
+
+    const html = ensureHtmlDocument(object.html, dimensions);
+
+    return {
+      html,
+      dimensions,
+    };
+  }
+}
+
+const buildPosterPrompt = (
+  request: PosterGenerationRequest,
+  metadata: ContentMetadata,
+  dimensions: PosterDimensions,
+): string => {
+  const stylePrompt = POSTER_STYLE_PROMPTS[request.style];
+  const ratio = request.ratio;
+
+  return `
+${stylePrompt}
+
+内容：
+"${request.caption}"
+
+内容分析：
+- 类型：${metadata.type}
+- 字数：${metadata.length}
+- 情绪：${metadata.sentiment}
+- 关键词：${metadata.keywords.join("、") || "无"}
+- 是否包含时间：${metadata.hasTime ? "是" : "否"}
+- 是否包含地点：${metadata.hasLocation ? "是" : "否"}
+- 是否包含表情：${metadata.hasEmoji ? "是" : "否"}
+
+画布尺寸：${dimensions.width}x${dimensions.height}px（比例 ${ratio}）
+
+生成要求：
+1. 输出完整 HTML 文档，包含 <style> 内联 CSS。
+2. 只使用系统字体，不要引用外部图片、字体或网络资源。
+3. 需要确保正文可读、层级清晰。
+4. 适合小红书分享风格，支持中文排版。
+5. 使用 CSS Grid 或 Flex，加入适度装饰元素。
+6. 背景、阴影、渐变等效果可用，但保持性能友好。
+7. 页面内容必须限制在指定尺寸内，不要出现滚动条。
+
+输出：仅输出完整 HTML 文档。
+`;
+};
+
+const analyzeContent = (caption: string): ContentMetadata => {
+  const normalized = caption.trim();
+  const length = normalized.length;
+  const hasEmoji = EMOJI_REGEX.test(normalized);
+
+  const hasTime =
+    /(\d{1,2}[:：]\d{2})|今天|明天|后天|周末|星期|周[一二三四五六日天]/.test(
+      normalized,
+    );
+  const hasLocation = /(在|到|去).{0,6}(附近|地铁|公园|广场|路|街)/.test(
+    normalized,
+  );
+
+  const keywords =
+    normalized.match(/[A-Za-z0-9\u4e00-\u9fff]{2,}/g)?.slice(0, 6) ?? [];
+
+  const type = determineType(normalized);
+  const sentiment = determineSentiment(normalized);
+
+  return {
+    type,
+    length,
+    sentiment,
+    keywords,
+    hasTime,
+    hasLocation,
+    hasEmoji,
+  };
+};
+
+const determineType = (
+  text: string,
+): ContentMetadata["type"] => {
+  if (/(学习|课程|讲座|培训|分享|读书)/.test(text)) return "knowledge";
+  if (/(旅行|出游|露营|徒步|探店|打卡)/.test(text)) return "lifestyle";
+  if (/(会议|项目|合作|创业|招募|行业)/.test(text)) return "business";
+  if (/(聚会|约饭|吃饭|运动|健身|看展)/.test(text)) return "event";
+  return "emotional";
+};
+
+const determineSentiment = (
+  text: string,
+): ContentMetadata["sentiment"] => {
+  if (/[!！]/.test(text)) return "excited";
+  if (/(温柔|治愈|陪伴|一起)/.test(text)) return "calm";
+  if (/(开心|快乐|期待|喜欢)/.test(text)) return "positive";
+  return "neutral";
+};
+
+const ensureHtmlDocument = (
+  rawHtml: string,
+  dimensions: PosterDimensions,
+): string => {
+  const trimmed = rawHtml.trim();
+  const hasHtmlTag = /<html[\s>]/i.test(trimmed);
+  const baseStyle = `
+    html, body {
+      margin: 0;
+      padding: 0;
+      width: ${dimensions.width}px;
+      height: ${dimensions.height}px;
+      overflow: hidden;
+    }
+    body {
+      display: flex;
+      align-items: stretch;
+      justify-content: stretch;
+      background: #ffffff;
+    }
+  `;
+
+  if (hasHtmlTag) {
+    if (/<style[\s>]/i.test(trimmed)) {
+      return trimmed.replace(
+        /<style[\s>][\s\S]*?<\/style>/i,
+        (match) => match.replace("</style>", `${baseStyle}\n</style>`),
+      );
+    }
+
+    return trimmed.replace(
+      /<head[\s>]/i,
+      `<head><style>${baseStyle}</style>`,
+    );
+  }
+
+  return `<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <style>
+      ${baseStyle}
+    </style>
+  </head>
+  <body>
+    ${trimmed}
+  </body>
+</html>`;
+};
+
+export const resolvePosterStyle = (
+  style?: number | PosterStyleKey,
+): PosterStyleKey => {
+  if (typeof style === "number") {
+    const index = Number.isFinite(style) ? Math.floor(style) : 0;
+    const normalized =
+      ((index % POSTER_STYLE_KEYS.length) + POSTER_STYLE_KEYS.length) %
+      POSTER_STYLE_KEYS.length;
+    return POSTER_STYLE_KEYS[normalized];
+  }
+
+  if (style && POSTER_STYLE_KEYS.includes(style)) {
+    return style;
+  }
+
+  return "fresh";
+};

--- a/apps/backend/src/services/PosterStorageService.ts
+++ b/apps/backend/src/services/PosterStorageService.ts
@@ -1,0 +1,63 @@
+import path from "path";
+import { promises as fs } from "fs";
+import { env } from "../lib/env";
+
+const DEFAULT_POSTER_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
+
+export class PosterStorageService {
+  private postersDir: string;
+
+  constructor() {
+    const defaultPostersDir =
+      process.platform === "win32"
+        ? path.join(process.cwd(), "posters")
+        : "/mnt/oss/posters";
+    this.postersDir = env.POSTERS_DIR ?? defaultPostersDir;
+  }
+
+  async savePoster(imageBuffer: Buffer, filename: string): Promise<string> {
+    await fs.mkdir(this.postersDir, { recursive: true });
+    const filepath = path.join(this.postersDir, filename);
+    await fs.writeFile(filepath, imageBuffer);
+    return filename;
+  }
+
+  getPosterUrl(filename: string, origin: string): string {
+    return `${origin}/api/poster/download/${encodeURIComponent(filename)}`;
+  }
+
+  async readPoster(filename: string): Promise<Buffer | null> {
+    const filepath = path.join(this.postersDir, filename);
+    try {
+      await fs.access(filepath);
+      return await fs.readFile(filepath);
+    } catch {
+      return null;
+    }
+  }
+
+  async cleanupOldPosters(
+    maxAgeMs: number = DEFAULT_POSTER_MAX_AGE_MS,
+  ): Promise<void> {
+    try {
+      const entries = await fs.readdir(this.postersDir, {
+        withFileTypes: true,
+      });
+      const now = Date.now();
+
+      await Promise.all(
+        entries
+          .filter((entry) => entry.isFile())
+          .map(async (entry) => {
+            const filepath = path.join(this.postersDir, entry.name);
+            const stats = await fs.stat(filepath);
+            if (now - stats.mtimeMs > maxAgeMs) {
+              await fs.unlink(filepath);
+            }
+          }),
+      );
+    } catch {
+      // Ignore cleanup errors to avoid breaking server.
+    }
+  }
+}

--- a/apps/backend/src/services/PosterStylePrompts.ts
+++ b/apps/backend/src/services/PosterStylePrompts.ts
@@ -1,0 +1,76 @@
+export const POSTER_STYLE_KEYS = [
+  "fresh",
+  "minimal",
+  "warm",
+  "modern",
+  "elegant",
+] as const;
+
+export type PosterStyleKey = (typeof POSTER_STYLE_KEYS)[number];
+
+export const STYLE_INDEX_TO_KEY: Record<number, PosterStyleKey> = {
+  0: "fresh",
+  1: "minimal",
+  2: "warm",
+  3: "modern",
+  4: "elegant",
+};
+
+export const POSTER_STYLE_PROMPTS: Record<PosterStyleKey, string> = {
+  fresh: `你是小红书海报设计师。请生成清新、活泼、富有亲和力的海报。
+
+设计风格：
+- 轻快、明亮、舒展
+- 使用柔和但有活力的渐变或色块
+- 可加入轻量装饰元素（圆点、斜线、贴纸感几何形）
+
+布局要求：
+- 单页海报，明确视觉层级
+- 标题突出、留白充足
+- 可使用 CSS Grid 或 Flex 进行布局
+`,
+  minimal: `你是极简风格海报设计师。请生成简洁、克制、专业感强的海报。
+
+设计风格：
+- 低饱和度配色，强调留白
+- 结构清晰，突出文字内容
+- 轻量阴影或细线条强调层次
+
+布局要求：
+- 单页海报，主视觉为文字
+- 使用 CSS Grid 或 Flex 进行排版
+`,
+  warm: `你是温暖治愈风格的海报设计师。请生成柔和、温馨、有陪伴感的海报。
+
+设计风格：
+- 暖色系渐变或柔和背景
+- 字体圆润、排版舒展
+- 可加入柔和阴影或半透明元素
+
+布局要求：
+- 单页海报，强调情绪氛围
+- 适度加入装饰元素烘托温度
+`,
+  modern: `你是现代潮流海报设计师。请生成时髦、利落、有节奏感的海报。
+
+设计风格：
+- 强对比与几何元素
+- 使用大胆排版和层次
+- 可加入倾斜、旋转等动感元素
+
+布局要求：
+- 单页海报，强调节奏感和视觉冲击
+- 使用 CSS Grid 或 Flex 进行布局
+`,
+  elegant: `你是优雅精致风格海报设计师。请生成高级、克制、细节精致的海报。
+
+设计风格：
+- 稳重配色，注重细节
+- 使用细腻阴影、柔和渐变
+- 适度使用小装饰元素（细线、分隔线）
+
+布局要求：
+- 单页海报，主视觉为标题与关键信息
+- 排版规整，留白舒适
+`,
+};

--- a/apps/backend/src/services/PuppeteerRenderService.ts
+++ b/apps/backend/src/services/PuppeteerRenderService.ts
@@ -1,0 +1,69 @@
+import chromium from "@sparticuz/chromium";
+import puppeteer, { Browser } from "puppeteer-core";
+import type { PosterDimensions } from "./HtmlPosterService";
+
+export class PuppeteerRenderService {
+  private browser: Browser | null = null;
+
+  async renderHtmlToPng(
+    html: string,
+    dimensions: PosterDimensions,
+  ): Promise<Buffer> {
+    const browser = await this.getBrowser();
+    const page = await browser.newPage();
+
+    try {
+      await page.setViewport({
+        width: dimensions.width,
+        height: dimensions.height,
+        deviceScaleFactor: 2,
+      });
+      await page.setContent(html, { waitUntil: "networkidle0" });
+      await page.evaluateHandle("document.fonts.ready");
+
+      const screenshot = await page.screenshot({
+        type: "png",
+        clip: {
+          x: 0,
+          y: 0,
+          width: dimensions.width,
+          height: dimensions.height,
+        },
+        optimizeForSpeed: false,
+      });
+
+      return screenshot as Buffer;
+    } finally {
+      await page.close();
+    }
+  }
+
+  async getBrowser(): Promise<Browser> {
+    if (!this.browser || !this.browser.connected) {
+      this.browser = await puppeteer.launch({
+        args: [
+          ...chromium.args,
+          "--no-sandbox",
+          "--disable-setuid-sandbox",
+          "--disable-dev-shm-usage",
+          "--disable-gpu",
+          "--single-process",
+          "--no-zygote",
+          "--font-render-hinting=none",
+        ],
+        defaultViewport: chromium.defaultViewport,
+        executablePath: await chromium.executablePath(),
+        headless: chromium.headless,
+        ignoreHTTPSErrors: true,
+      });
+    }
+    return this.browser;
+  }
+
+  async cleanup(): Promise<void> {
+    if (this.browser) {
+      await this.browser.close();
+      this.browser = null;
+    }
+  }
+}

--- a/apps/backend/src/services/posterServices.ts
+++ b/apps/backend/src/services/posterServices.ts
@@ -1,0 +1,7 @@
+import { HtmlPosterService } from "./HtmlPosterService";
+import { PosterStorageService } from "./PosterStorageService";
+import { PuppeteerRenderService } from "./PuppeteerRenderService";
+
+export const htmlPosterService = new HtmlPosterService();
+export const posterStorageService = new PosterStorageService();
+export const posterRenderService = new PuppeteerRenderService();

--- a/apps/frontend/src/composables/useGenerateHtmlPoster.ts
+++ b/apps/frontend/src/composables/useGenerateHtmlPoster.ts
@@ -1,0 +1,54 @@
+import { computed, ref } from "vue";
+import { client } from "@/lib/rpc";
+import type { PosterRatio } from "@partner-up-dev/backend";
+
+const isWeChatBrowser = (): boolean =>
+  /MicroMessenger/i.test(navigator.userAgent);
+
+export const useGenerateHtmlPoster = () => {
+  const isGenerating = ref(false);
+  const posterUrl = ref<string | null>(null);
+
+  const generatePoster = async (
+    caption: string,
+    style: number,
+    ratio: PosterRatio = "3:4",
+    saveOnServer?: boolean,
+  ) => {
+    isGenerating.value = true;
+
+    try {
+      const shouldSave = saveOnServer ?? isWeChatBrowser();
+      const res = await client.api.poster.html.$post({
+        json: {
+          caption,
+          style,
+          ratio,
+          saveOnServer: shouldSave,
+        },
+      });
+
+      if (!res.ok) {
+        throw new Error("Poster generation failed");
+      }
+
+      const data = await res.json();
+      posterUrl.value = data.posterUrl;
+      return data;
+    } finally {
+      isGenerating.value = false;
+    }
+  };
+
+  const clearPoster = () => {
+    posterUrl.value = null;
+  };
+
+  return {
+    generatePoster,
+    clearPoster,
+    isGenerating: computed(() => isGenerating.value),
+    posterUrl: computed(() => posterUrl.value),
+    isWeChatBrowser,
+  };
+};

--- a/apps/frontend/src/lib/mock-rpc.ts
+++ b/apps/frontend/src/lib/mock-rpc.ts
@@ -88,6 +88,34 @@ const mockClient = {
         },
       },
     },
+    poster: {
+      html: {
+        $post: async ({
+          json,
+        }: {
+          json: {
+            caption: string;
+            style?: number | string;
+            ratio?: string;
+            saveOnServer?: boolean;
+          };
+        }) => {
+          await new Promise((resolve) => setTimeout(resolve, 500));
+
+          const placeholder =
+            "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==";
+
+          return {
+            ok: true,
+            status: 200,
+            json: async () => ({
+              posterUrl: placeholder,
+              saved: Boolean(json.saveOnServer),
+            }),
+          } as Response;
+        },
+      },
+    },
   },
 } as unknown as ReturnType<typeof hc<AppType>>;
 

--- a/docs/plan/llm-generated-html-posters/PLAN.md
+++ b/docs/plan/llm-generated-html-posters/PLAN.md
@@ -30,12 +30,12 @@ Upgrade the current XHS poster generation system from template-based to **LLM-ge
 Based on the referenced implementation, we'll adopt these key patterns:
 
 1. **Dynamic HTML Generation**: LLM creates complete HTML with inline CSS
-2. **Server-Side Rendering**: Use Playwright for consistent, high-quality image generation
+2. **Server-Side Rendering**: Use Puppeteer (Chromium) for consistent, high-quality image generation
 3. **Flexible Styling**: AI-driven layout and visual design decisions
 4. **Content-Aware Design**: Layout adapts to content semantics
 5. **Smart Storage**: Conditional poster saving for WeChat browser optimization
 
-### Rendering Strategy: Server-Side with Playwright
+### Rendering Strategy: Server-Side with Puppeteer (Chromium)
 
 **Advantages**:
 
@@ -56,7 +56,7 @@ Based on the referenced implementation, we'll adopt these key patterns:
 ```
 Backend (New):
 ├── HtmlPosterService.ts         # LLM HTML generation service
-├── BrowserRenderService.ts      # Playwright-based PNG rendering
+├── BrowserRenderService.ts      # Puppeteer-based PNG rendering
 ├── PosterStorageService.ts      # Conditional poster file management
 └── PosterStylePrompts.ts        # Style prompt definitions
 
@@ -97,7 +97,7 @@ export class HtmlPosterService {
 **Features**:
 
 - Uses existing LLMService with new prompt system
-- Generates complete HTML with inline CSS optimized for Playwright rendering
+- Generates complete HTML with inline CSS optimized for Puppeteer rendering
 - Adapts layout based on content length and semantic analysis
 - Supports dynamic color schemes and typography
 - Includes microelements like icons, dividers, decorative elements
@@ -194,7 +194,7 @@ export class PosterStorageService {
 
 **File**: `apps/backend/src/services/PosterStylePrompts.ts`
 
-Define detailed prompts for each style that leverage full Playwright CSS support:
+Define detailed prompts for each style that leverage full Puppeteer CSS support:
 
 ```typescript
 export const POSTER_STYLE_PROMPTS = {
@@ -221,7 +221,7 @@ function isWeChatBrowser(userAgent: string): boolean {
 const puppeteerRenderService = new PuppeteerRenderService();
 
 export const posterRoute = app.post(
-  "/generate-html-poster",
+  "/html",
   zValidator("json", generatePosterSchema),
   async (c) => {
     const { caption, style, ratio, saveOnServer } = c.req.valid("json");

--- a/docs/plan/llm-generated-html-posters/RESULT.md
+++ b/docs/plan/llm-generated-html-posters/RESULT.md
@@ -1,0 +1,68 @@
+# LLM-Generated HTML Posters — Implementation Result
+
+## Summary
+
+- Replaced client-side html2canvas posters with a server-rendered HTML → PNG pipeline powered by Puppeteer + Chromium.
+- Added LLM-driven HTML generation with content-aware prompts and style mapping.
+- Wired both Xiaohongshu sharing and WeChat share card thumbnails to the new API.
+
+## Plan Revisions
+
+- Standardized on **Puppeteer + @sparticuz/chromium** for rendering (instead of Playwright references in the original plan).
+- Preserved existing 5 style indices and mapped them to new LLM style keys: `fresh`, `minimal`, `warm`, `modern`, `elegant`.
+- Exposed a single `/api/poster/html` API that returns either a `data:` URL (default) or a persisted URL for WeChat.
+
+## Backend Changes
+
+### New Services
+
+- `HtmlPosterService`
+  - Generates HTML via LLM with content analysis and detailed prompts.
+  - Ensures a valid HTML document and injects base sizing styles.
+- `PuppeteerRenderService`
+  - Renders HTML to PNG using shared Chromium instance.
+  - High-DPI screenshot (deviceScaleFactor = 2) for crisp output.
+- `PosterStorageService`
+  - Persists rendered PNGs to the posters directory and provides download URLs.
+  - Cleanup job removes stale posters (default: 7 days).
+
+### New API
+
+`POST /api/poster/html`
+
+**Request**
+```json
+{
+  "caption": "周末一起去公园散步吧🌿",
+  "style": 0,
+  "ratio": "3:4",
+  "saveOnServer": false
+}
+```
+
+**Response**
+```json
+{
+  "posterUrl": "data:image/png;base64,...",
+  "saved": false
+}
+```
+
+If `saveOnServer` is `true` (or the request is detected as WeChat browser), the response becomes:
+```json
+{
+  "posterUrl": "https://<host>/api/poster/download/<filename>.png",
+  "saved": true
+}
+```
+
+## Frontend Changes
+
+- Introduced `useGenerateHtmlPoster` composable to call the new API.
+- Updated **ShareToXiaohongshu** to display the server-rendered poster and handle both data URLs and remote URLs.
+- Updated **ShareToWechatChat** to generate and use server-stored poster URLs for WeChat share card thumbnails.
+
+## Operational Notes
+
+- Poster cleanup runs every 24 hours; stale posters older than 7 days are removed.
+- The existing upload endpoints remain untouched and can still be used elsewhere.


### PR DESCRIPTION
### Motivation

- Replace the fragile client-side html2canvas template pipeline with an LLM-driven HTML → PNG server pipeline for richer, content-aware Xiaohongshu posters and WeChat share thumbnails.  
- Use server-side Chromium (Puppeteer + @sparticuz/chromium) to ensure consistent high-quality rendering across platforms.  
- Keep maintainability first by isolating responsibilities into small services (LLM HTML generation, rendering, storage) and a single poster API.  

### Description

- Backend: added LLM-driven poster generation and rendering services and routes: `HtmlPosterService`, `PuppeteerRenderService`, `PosterStorageService`, `PosterStylePrompts`, and a `posterServices` aggregator, plus `POST /api/poster/html` and `GET /api/poster/download/:filename` controller (`apps/backend/src/services/*`, `apps/backend/src/controllers/poster.controller.ts`).  
- Backend integration: wired poster routes into `apps/backend/src/index.ts`, added periodic cleanup for stored posters and graceful Puppeteer shutdown, and exposed `PosterRatio` in the backend export.  
- Dependencies: added `puppeteer-core` and `@sparticuz/chromium` to `apps/backend/package.json` to support serverless-friendly Chromium rendering.  
- Frontend: added `useGenerateHtmlPoster` composable and updated Xiaohongshu and WeChat sharing components to use the new API and handle both `data:` image URLs and persisted server URLs (`apps/frontend/src/composables/useGenerateHtmlPoster.ts`, updates to `ShareToXiaohongshu.vue` and `ShareToWechatChat.vue`).  
- Local dev conveniences: updated `mock-rpc` to simulate the poster API and updated the plan docs plus added `docs/plan/llm-generated-html-posters/RESULT.md` documenting implemented changes and plan revisions.  

### Testing

- Attempted dependency install with `pnpm --filter @partner-up-dev/backend install`, but it failed due to a 403 from the npm registry for `@types/bcryptjs`, so full backend build/test could not be executed.  
- Started the frontend dev server with `pnpm --filter @partner-up-dev/frontend dev` and verified the Vite server responded (HTTP 200 on `http://localhost:4173`).  
- Attempted an automated screenshot via Playwright to exercise the frontend flow, but the headless run failed to load the dev server (`net::ERR_EMPTY_RESPONSE`) when executed from the automation environment, so visual end-to-end rendering was not validated.  
- No automated unit tests were added; integration testing of the full backend poster pipeline remains pending until backend dependencies can be installed and the Puppeteer environment runs successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f6c4988e0832c9e0d19cca84adfd8)