### PR TITLE
fix(anchor-pr): attended-only check-in with unknown fallback

### DIFF
--- a/apps/backend/src/controllers/anchor-pr.controller.ts
+++ b/apps/backend/src/controllers/anchor-pr.controller.ts
@@ -38,7 +38,7 @@ import {
 const app = new Hono<AuthEnv>();
 const prRepo = new PartnerRequestRepository();
 const slotCheckInSchema = z.object({
-  didAttend: z.boolean(),
+  didAttend: z.boolean().optional(),
   wouldJoinAgain: z.boolean().nullable().optional(),
 });
 const acceptAlternativeBatchSchema = z.object({
@@ -251,8 +251,12 @@ export const anchorPRRoute = app
       await ensureAnchorPR(id);
       const { openId } = await requireAnchorAuthenticatedIdentity(c);
       const { didAttend, wouldJoinAgain } = c.req.valid("json");
+      if (didAttend === false) {
+        throw new HTTPException(400, {
+          message: "didAttend=false is no longer supported",
+        });
+      }
       const result = await checkIn(id, openId, {
-        didAttend,
         wouldJoinAgain: wouldJoinAgain ?? null,
       });
       return c.json(result);

--- a/apps/backend/src/domains/pr-core/use-cases/check-in.ts
+++ b/apps/backend/src/domains/pr-core/use-cases/check-in.ts
@@ -17,7 +17,7 @@ const userReliabilityRepo = new UserReliabilityRepository();
 export async function checkIn(
   id: PRId,
   openId: string,
-  payload: { didAttend: boolean; wouldJoinAgain: boolean | null },
+  payload: { wouldJoinAgain: boolean | null },
 ): Promise<PublicPR> {
   const request = await prRepo.findById(id);
   if (!request) {
@@ -48,7 +48,7 @@ export async function checkIn(
   if (!updatedSlot) {
     throw new HTTPException(500, { message: "Failed to submit check-in" });
   }
-  if (payload.didAttend && slot.status !== "ATTENDED") {
+  if (slot.status !== "ATTENDED") {
     await userReliabilityRepo.applyDelta(user.id, { attended: 1 });
   }
 
@@ -61,7 +61,7 @@ export async function checkIn(
       prId: id,
       partnerId: slot.id,
       userId: user.id,
-      didAttend: payload.didAttend,
+      didAttend: true,
     },
   );
   void writeToOutbox(event);
@@ -71,7 +71,7 @@ export async function checkIn(
     action: "partner.check_in",
     aggregateType: "partner_request",
     aggregateId: String(id),
-    detail: { partnerId: slot.id, didAttend: payload.didAttend },
+    detail: { partnerId: slot.id, didAttend: true },
   });
 
   const latest = await prRepo.findById(id);

--- a/apps/backend/src/repositories/PartnerRepository.ts
+++ b/apps/backend/src/repositories/PartnerRepository.ts
@@ -311,7 +311,6 @@ export class PartnerRepository {
   async reportCheckIn(
     id: PartnerId,
     payload: {
-      didAttend: boolean;
       wouldJoinAgain: boolean | null;
     },
   ) {
@@ -319,10 +318,10 @@ export class PartnerRepository {
     const result = await db
       .update(partners)
       .set({
-        status: payload.didAttend ? "ATTENDED" : undefined,
-        attendedAt: payload.didAttend ? now : undefined,
+        status: "ATTENDED",
+        attendedAt: now,
         checkInAt: now,
-        didAttend: payload.didAttend,
+        didAttend: true,
         wouldJoinAgain: payload.wouldJoinAgain,
       })
       .where(eq(partners.id, id))

--- a/apps/frontend/src/domains/pr/queries/useAnchorPR.ts
+++ b/apps/frontend/src/domains/pr/queries/useAnchorPR.ts
@@ -35,7 +35,6 @@ type AnchorPRVerifyBookingContactInput = {
 
 type AnchorPRCheckInInput = {
   id: PRId;
-  didAttend: boolean;
   wouldJoinAgain: boolean | null;
 };
 
@@ -378,16 +377,11 @@ export const useCheckInAnchorPRSlot = () => {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: async ({
-      id,
-      didAttend,
-      wouldJoinAgain,
-    }: AnchorPRCheckInInput) => {
+    mutationFn: async ({ id, wouldJoinAgain }: AnchorPRCheckInInput) => {
       const res = await client.api.apr[":id"]["check-in"].$post(
         {
           param: { id: id.toString() },
           json: {
-            didAttend,
             wouldJoinAgain,
           },
         },

--- a/apps/frontend/src/domains/pr/ui/sections/AnchorAttendancePanel.vue
+++ b/apps/frontend/src/domains/pr/ui/sections/AnchorAttendancePanel.vue
@@ -12,19 +12,10 @@
     <button
       v-if="hasJoined && canCheckIn"
       class="checkin-attended-btn"
-      @click="emit('prepare-check-in', true)"
+      @click="emit('prepare-check-in')"
       :disabled="checkInPending"
     >
       {{ checkInPending ? t("prPage.checkingIn") : t("prPage.checkInAttended") }}
-    </button>
-
-    <button
-      v-if="hasJoined && canCheckIn"
-      class="checkin-missed-btn"
-      @click="emit('prepare-check-in', false)"
-      :disabled="checkInPending"
-    >
-      {{ checkInPending ? t("prPage.checkingIn") : t("prPage.checkInMissed") }}
     </button>
   </section>
 
@@ -73,7 +64,7 @@ defineProps<{
 
 const emit = defineEmits<{
   "confirm-slot": [];
-  "prepare-check-in": [didAttend: boolean];
+  "prepare-check-in": [];
   "submit-check-in": [wouldJoinAgain: boolean];
   "cancel-check-in": [];
 }>();
@@ -95,8 +86,7 @@ const { t } = useI18n();
 }
 
 .confirm-slot-btn,
-.checkin-attended-btn,
-.checkin-missed-btn {
+.checkin-attended-btn {
   @include mx.pu-font(label-large);
   flex: 1;
   min-width: 0;
@@ -110,10 +100,6 @@ const { t } = useI18n();
 
 .checkin-attended-btn {
   @include mx.pu-rect-action(tertiary, default);
-}
-
-.checkin-missed-btn {
-  @include mx.pu-rect-action(outline, default);
 }
 
 .checkin-followup {

--- a/apps/frontend/src/domains/pr/ui/sections/AnchorPRActionsBar.vue
+++ b/apps/frontend/src/domains/pr/ui/sections/AnchorPRActionsBar.vue
@@ -24,7 +24,7 @@
     :confirm-pending="confirmPending"
     :check-in-pending="checkInPending"
     @confirm-slot="emit('confirm-slot')"
-    @prepare-check-in="emit('prepare-check-in', $event)"
+    @prepare-check-in="emit('prepare-check-in')"
     @submit-check-in="emit('submit-check-in', $event)"
     @cancel-check-in="emit('cancel-check-in')"
   />
@@ -56,7 +56,7 @@ const emit = defineEmits<{
   join: [];
   exit: [];
   "confirm-slot": [];
-  "prepare-check-in": [didAttend: boolean];
+  "prepare-check-in": [];
   "submit-check-in": [wouldJoinAgain: boolean];
   "cancel-check-in": [];
   "edit-content": [];

--- a/apps/frontend/src/domains/pr/ui/sections/AnchorPRPrimaryActionLane.vue
+++ b/apps/frontend/src/domains/pr/ui/sections/AnchorPRPrimaryActionLane.vue
@@ -65,15 +65,6 @@
       </button>
 
       <button
-        v-if="showSecondaryCheckInMissed"
-        class="lane-secondary-btn"
-        :disabled="checkInPending"
-        @click="emit('prepare-check-in', false)"
-      >
-        {{ checkInPending ? t("prPage.checkingIn") : t("prPage.checkInMissed") }}
-      </button>
-
-      <button
         v-if="showRecoveryShortcut"
         class="lane-secondary-btn"
         @click="handleRecoveryShortcut"
@@ -129,7 +120,7 @@ const emit = defineEmits<{
   join: [];
   exit: [];
   "confirm-slot": [];
-  "prepare-check-in": [didAttend: boolean];
+  "prepare-check-in": [];
   "go-recovery": [];
 }>();
 
@@ -199,11 +190,6 @@ const primaryActionPending = computed(() => {
 
 const showSecondaryExit = computed(
   () => props.section.viewer.canExit && primaryActionType.value !== "EXIT",
-);
-
-const showSecondaryCheckInMissed = computed(
-  () =>
-    props.section.viewer.canCheckIn && primaryActionType.value === "CHECK_IN",
 );
 
 const showRecoveryShortcut = computed(
@@ -287,7 +273,7 @@ const handlePrimaryAction = () => {
 
   switch (primaryActionType.value) {
     case "CHECK_IN":
-      emit("prepare-check-in", true);
+      emit("prepare-check-in");
       return;
     case "CONFIRM_SLOT":
       emit("confirm-slot");

--- a/apps/frontend/src/domains/pr/ui/sections/PRPartnerSection.vue
+++ b/apps/frontend/src/domains/pr/ui/sections/PRPartnerSection.vue
@@ -81,21 +81,10 @@
         v-if="section.scenario === 'ANCHOR' && section.viewer.canCheckIn"
         class="partner-section__secondary-btn"
         :disabled="checkInPending"
-        @click="emit('prepare-check-in', true)"
+        @click="emit('prepare-check-in')"
       >
         {{
           checkInPending ? t("prPage.checkingIn") : t("prPage.checkInAttended")
-        }}
-      </button>
-
-      <button
-        v-if="section.scenario === 'ANCHOR' && section.viewer.canCheckIn"
-        class="partner-section__secondary-btn"
-        :disabled="checkInPending"
-        @click="emit('prepare-check-in', false)"
-      >
-        {{
-          checkInPending ? t("prPage.checkingIn") : t("prPage.checkInMissed")
         }}
       </button>
     </div>
@@ -462,7 +451,7 @@ const emit = defineEmits<{
   join: [];
   exit: [];
   "confirm-slot": [];
-  "prepare-check-in": [didAttend: boolean];
+  "prepare-check-in": [];
   "submit-check-in": [wouldJoinAgain: boolean];
   "cancel-check-in": [];
   "toggle-reminder": [];

--- a/apps/frontend/src/domains/pr/use-cases/useAnchorAttendanceActions.ts
+++ b/apps/frontend/src/domains/pr/use-cases/useAnchorAttendanceActions.ts
@@ -22,7 +22,7 @@ export const useAnchorAttendanceActions = ({
   const { t } = useI18n();
   const confirmSlotMutation = useConfirmAnchorPRSlot();
   const checkInSlotMutation = useCheckInAnchorPRSlot();
-  const pendingCheckInDidAttend = ref<boolean | null>(null);
+  const checkInFollowupOpen = ref(false);
 
   const hasJoined = computed(
     () => pr.value?.partnerSection.viewer.isParticipant ?? false,
@@ -31,15 +31,12 @@ export const useAnchorAttendanceActions = ({
   const canConfirm = computed(() => pr.value?.partnerSection.viewer.canConfirm ?? false);
   const canCheckIn = computed(() => pr.value?.partnerSection.viewer.canCheckIn ?? false);
 
-  const checkInFollowupStatusLabel = computed(() => {
-    if (pendingCheckInDidAttend.value === true) {
-      return t("prPage.checkInFollowupForAttended");
-    }
-    return t("prPage.checkInFollowupForMissed");
-  });
+  const checkInFollowupStatusLabel = computed(
+    () => t("prPage.checkInFollowupForAttended"),
+  );
 
   const showCheckInFollowup = computed(
-    () => hasJoined.value && pendingCheckInDidAttend.value !== null,
+    () => hasJoined.value && checkInFollowupOpen.value,
   );
 
   const confirmPending = computed(() => confirmSlotMutation.isPending.value);
@@ -57,21 +54,20 @@ export const useAnchorAttendanceActions = ({
     onActionSuccess?.();
   };
 
-  const prepareCheckIn = (didAttend: boolean) => {
-    pendingCheckInDidAttend.value = didAttend;
+  const prepareCheckIn = () => {
+    checkInFollowupOpen.value = true;
   };
 
   const cancelPendingCheckIn = () => {
-    pendingCheckInDidAttend.value = null;
+    checkInFollowupOpen.value = false;
   };
 
   const submitCheckIn = async (wouldJoinAgain: boolean) => {
     if (id.value === null) return;
-    if (pendingCheckInDidAttend.value === null) return;
+    if (!checkInFollowupOpen.value) return;
 
     await checkInSlotMutation.mutateAsync({
       id: id.value,
-      didAttend: pendingCheckInDidAttend.value,
       wouldJoinAgain,
     });
 
@@ -79,12 +75,12 @@ export const useAnchorAttendanceActions = ({
       prId: id.value,
       prKind: "ANCHOR",
       scenarioType: pr.value?.core.type,
-      didAttend: pendingCheckInDidAttend.value,
+      didAttend: true,
       wouldJoinAgain,
     });
     onActionSuccess?.();
 
-    pendingCheckInDidAttend.value = null;
+    checkInFollowupOpen.value = false;
   };
 
   return {

--- a/apps/frontend/src/pages/AnchorPRPage.vue
+++ b/apps/frontend/src/pages/AnchorPRPage.vue
@@ -459,7 +459,6 @@ type DockActionKey =
   | "JOIN"
   | "CONFIRM"
   | "CHECKIN_ATTENDED"
-  | "CHECKIN_MISSED"
   | "CREATOR_EDIT"
   | "CREATOR_STATUS";
 
@@ -768,15 +767,6 @@ const dockActions = computed<DockActionItem[]>(() => {
         label: t("prPage.checkInAttended"),
         pendingLabel: t("prPage.checkingIn"),
         tone: "primary",
-        disabled: !viewer.canCheckIn,
-        pending: attendanceActions.checkInPending.value,
-        tip: checkInTip,
-      },
-      {
-        key: "CHECKIN_MISSED",
-        label: t("prPage.checkInMissed"),
-        pendingLabel: t("prPage.checkingIn"),
-        tone: "secondary",
         disabled: !viewer.canCheckIn,
         pending: attendanceActions.checkInPending.value,
         tip: checkInTip,
@@ -1100,11 +1090,7 @@ const handleDockAction = async (action: DockActionItem) => {
     return;
   }
   if (action.key === "CHECKIN_ATTENDED") {
-    attendanceActions.prepareCheckIn(true);
-    return;
-  }
-  if (action.key === "CHECKIN_MISSED") {
-    attendanceActions.prepareCheckIn(false);
+    attendanceActions.prepareCheckIn();
     return;
   }
   if (action.key === "CREATOR_EDIT") {
@@ -1171,7 +1157,7 @@ function mapDockActionToTrackType(
 ): "JOIN" | "CONFIRM_SLOT" | "CHECK_IN" | "EXIT" | null {
   if (key === "JOIN") return "JOIN";
   if (key === "CONFIRM") return "CONFIRM_SLOT";
-  if (key === "CHECKIN_ATTENDED" || key === "CHECKIN_MISSED") return "CHECK_IN";
+  if (key === "CHECKIN_ATTENDED") return "CHECK_IN";
   return null;
 }
 

--- a/docs/product/features/find-partner.md
+++ b/docs/product/features/find-partner.md
@@ -55,7 +55,7 @@
   - `T-1h` 时刻会自动释放仍为 `JOINED` 的槽位（变为 `RELEASED` 并从 PR 当前参与列表移除）。
   - `T-30min` 后禁止加入（event locked）。
 - Anchor PR 详情页提供“确认参与”动作，调用 `POST /api/apr/:id/confirm` 使槽位进入 `CONFIRMED`（若尚未确认）。
-- Anchor PR 详情页提供可选签到反馈（我已到场 / 我未到场），调用 `POST /api/apr/:id/check-in`；`didAttend=true` 时槽位进入 `ATTENDED`。
+- Anchor PR 详情页提供可选签到反馈（仅“我已到场”），调用 `POST /api/apr/:id/check-in`；提交后槽位进入 `ATTENDED`，并记录 `wouldJoinAgain`。未提交签到视为 `CHECKIN_UNKNOWN`（`didAttend=null`）。
 - `/me` 与 Anchor PR 详情页共用“通知订阅”卡片，查询/更新接口为：
   - `GET /api/wechat/notifications/subscriptions`
   - `POST /api/wechat/notifications/subscriptions`（`kind: "REMINDER_CONFIRMATION" | "BOOKING_RESULT" | "NEW_PARTNER"`, `enabled: boolean`）
@@ -109,6 +109,8 @@
 - `POST /api/wechat/notifications/subscriptions` 的 `kind=NEW_PARTNER` 关闭时会清理未执行的新搭子通知任务。
 - 仅 Anchor PR 在 `T-30min` 之后拒绝 join 请求（400）。
 - 仅 Anchor PR 在到达 `T-1h` 且槽位未确认时，会在读取/操作时懒触发自动释放，保证结构状态收敛。
+- Anchor PR 详情页签到仅展示“我已到场”；不再提供“我未到场”提交动作。
+- 未触发签到提交时，参与槽位 `didAttend` 保持 `null`，表示 `CHECKIN_UNKNOWN`。
 - 编辑弹窗与结构化创建页使用同一表单组件与同一校验逻辑。
 - `PATCH /api/cpr/:id/content` 与 `PATCH /api/apr/:id/content` 在修改时间导致任一活跃参与者产生冲突时返回 `409`，错误码 `JOIN_TIME_WINDOW_CONFLICT`。
 

--- a/docs/product/glossary.md
+++ b/docs/product/glossary.md
@@ -20,7 +20,7 @@
 - SettlementMode：资助结算时机（NONE / PLATFORM_PREPAID / PLATFORM_POSTPAID）。
 - ReimbursementStatus：报销状态（NONE / PENDING / APPROVED / REJECTED / PAID）。
 - Confirmation Window：Anchor PR 专属确认时序窗口（T-1h 自动释放未确认槽位；T-1h~T-30min 加入即确认；T-30min 后禁止加入）。
-- Check-in Signal：Anchor PR 专属签到回流信号（didAttend / wouldJoinAgain），用于近似到场率与复参与意愿。
+- Check-in Signal：Anchor PR 专属签到回流信号（attended only：`didAttend=true` + `wouldJoinAgain`）；未提交时保持 `didAttend=null`，记为 `CHECKIN_UNKNOWN`。
 - User（最小模型）：核心用户主体，`users.id` 使用 UUID；表内维护身份、角色与资料字段（`openid`、`role=anonymous/authenticated/service`、`nickname`、`sex`、`avatar`、`pin_hash`、`status`）。
 - UserReliability：用户可靠性统计表（`user_reliability`），维护 join / confirm / attend / release 计数与派生比率。
 - UserNotificationOpts：用户通知偏好表（`user_notification_opts`），当前维护 3 个公众号通知开关：`REMINDER_CONFIRMATION`（活动前提醒）、`BOOKING_RESULT`（场地预订结果）、`NEW_PARTNER`（新搭子）。

--- a/docs/product/overview.md
+++ b/docs/product/overview.md
@@ -41,7 +41,7 @@ PartnerUp MVP-HA 是一个协作效率产品（H-A）：把“群里的一句话
 - 在 Anchor PR 详情页执行“加入/退出 / 确认参与 / 签到”时，系统会强制校验「本地 authenticated 会话 + 用户已绑定微信 openid」。
 - 在 Community / Anchor PR 的参与名单中，每条 roster item 展示头像 + 昵称；点击后可进入该参与者资料页（只读）。
 - Community PR 详情页仅提供 `join/exit`。
-- Anchor PR 详情页提供 `join/exit`、确认参与与可选签到（到场/未到场）反馈，用于可靠性与信任回流。
+- Anchor PR 详情页提供 `join/exit`、确认参与与可选签到（仅“到场”）反馈；未提交签到默认为 `CHECKIN_UNKNOWN`，用于可靠性与信任回流。
 - Anchor PR 与 `/me` 页面共用“通知订阅”卡片，当前包含 3 个全局开关：`REMINDER_CONFIRMATION`（公众号提醒）、`BOOKING_RESULT`（场地预订结果）、`NEW_PARTNER`（新搭子）。
 - `REMINDER_CONFIRMATION` 开启后会按 `T-24h` 与 `T-2h` 触发服务号订阅通知提醒（模板消息通道保留为兼容兜底），关闭后会清理未执行提醒任务。
 - `NEW_PARTNER` 开启后，当你已加入的 Anchor PR 有新参与者加入时会触发服务号订阅通知。


### PR DESCRIPTION
## Summary
- switch Anchor PR check-in to attended-only flow (remove explicit "missed" submission)
- keep unknown fallback as didAttend = null when no check-in is submitted
- enforce backend contract: reject didAttend=false, accept omitted didAttend
- align product docs to attended-only + CHECKIN_UNKNOWN

## Validation
- pnpm --filter @partner-up-dev/backend build
- pnpm --filter @partner-up-dev/frontend build

Closes #43