### PR TITLE
feat(frontend): auto WeChat login on anchor routes and refine /me login flow

### DIFF
--- a/apps/frontend/src/app/AppRoot.vue
+++ b/apps/frontend/src/app/AppRoot.vue
@@ -5,9 +5,11 @@
 <script setup lang="ts">
 import { RouterView } from "vue-router";
 import { useAuthSessionBootstrap } from "@/processes/auth/useAuthSessionBootstrap";
+import { useRouteWeChatAutoLogin } from "@/processes/wechat/useRouteWeChatAutoLogin";
 import { useRouteWeChatShare } from "@/processes/wechat/useRouteWeChatShare";
 
 useAuthSessionBootstrap();
+useRouteWeChatAutoLogin();
 useRouteWeChatShare();
 </script>
 

--- a/apps/frontend/src/domains/user/queries/useLoginWithPin.ts
+++ b/apps/frontend/src/domains/user/queries/useLoginWithPin.ts
@@ -1,0 +1,61 @@
+import { useMutation, useQueryClient } from "@tanstack/vue-query";
+import type { AuthSessionPayload } from "@/shared/auth/useUserSessionStore";
+import { client } from "@/lib/rpc";
+import { queryKeys } from "@/shared/api/query-keys";
+import { i18n } from "@/locales/i18n";
+
+type LoginWithPinInput = {
+  userId: string;
+  userPin: string;
+};
+
+export const useLoginWithPin = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({
+      userId,
+      userPin,
+    }: LoginWithPinInput): Promise<AuthSessionPayload> => {
+      const res = await client.api.auth.session.$post(
+        {
+          json: {
+            userId,
+            userPin,
+          },
+        },
+        {
+          init: {
+            credentials: "include",
+          },
+        },
+      );
+
+      if (!res.ok) {
+        const error = (await res.json()) as { error?: string };
+        throw new Error(
+          error.error || i18n.global.t("errors.loginWithPinFailed"),
+        );
+      }
+
+      return (await res.json()) as AuthSessionPayload;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.user.me(),
+      });
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.pr.mineCreated(),
+      });
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.pr.mineJoined(),
+      });
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.wechat.notificationSubscriptions(),
+      });
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.wechat.reminderSubscription(),
+      });
+    },
+  });
+};

--- a/apps/frontend/src/locales/schema.ts
+++ b/apps/frontend/src/locales/schema.ts
@@ -394,7 +394,6 @@ export interface MessageSchema {
     title: string;
     description: string;
     loading: string;
-    authHint: string;
     register: {
       title: string;
       action: string;
@@ -416,7 +415,6 @@ export interface MessageSchema {
     };
     wechat: {
       title: string;
-      authHint: string;
       boundHint: string;
       nonWechatHint: string;
       unboundHint: string;
@@ -426,6 +424,24 @@ export interface MessageSchema {
       bindSuccess: string;
       bindConflict: string;
       bindFailed: string;
+    };
+    wechatLogin: {
+      title: string;
+      wechatHint: string;
+      nonWechatHint: string;
+      action: string;
+      pending: string;
+    };
+    pinLogin: {
+      title: string;
+      description: string;
+      userIdLabel: string;
+      userIdPlaceholder: string;
+      pinLabel: string;
+      pinPlaceholder: string;
+      pinFormatHint: string;
+      action: string;
+      pending: string;
     };
     reminder: {
       title: string;
@@ -814,6 +830,7 @@ export interface MessageSchema {
     updateCurrentUserProfileFailed: string;
     updateCurrentUserAvatarFailed: string;
     startWechatBindFailed: string;
+    loginWithPinFailed: string;
     registerLocalAccountFailed: string;
   };
   posterStyles: {

--- a/apps/frontend/src/locales/zh-CN.jsonc
+++ b/apps/frontend/src/locales/zh-CN.jsonc
@@ -656,7 +656,6 @@
     "title": "我的",
     "description": "管理微信绑定、服务通知、本地 PIN 和账户资料。",
     "loading": "正在加载你的资料...",
-    "authHint": "当前还是匿名状态。你可以先在这里注册本地账户，或在发布 / 加入搭子请求时自动生成账户和 PIN。",
     "register": {
       "title": "注册本地账户",
       "action": "立即注册",
@@ -678,7 +677,6 @@
     },
     "wechat": {
       "title": "绑定微信",
-      "authHint": "需要先拥有本地账户后，才能把当前账户绑定到微信。",
       "boundHint": "当前账户已绑定微信，可继续使用服务通知和微信内身份识别。",
       "nonWechatHint": "请在微信内打开本页后再绑定，这样才能完成官方授权。",
       "unboundHint": "在微信内完成一次授权后，当前本地账户就会与该微信账号绑定。",
@@ -688,6 +686,24 @@
       "bindSuccess": "微信绑定成功。",
       "bindConflict": "该微信账号已经绑定到其他用户，当前账户未发生变更。",
       "bindFailed": "微信绑定失败，请稍后重试。"
+    },
+    "wechatLogin": {
+      "title": "微信登录",
+      "wechatHint": "在微信内登录可恢复你已绑定的活动身份。",
+      "nonWechatHint": "请在微信内打开本页后再进行微信登录。",
+      "action": "微信登录",
+      "pending": "拉起授权中..."
+    },
+    "pinLogin": {
+      "title": "PIN 登录",
+      "description": "输入你保存的用户 ID 与 PIN，恢复本地账户。",
+      "userIdLabel": "用户 ID",
+      "userIdPlaceholder": "输入用户 ID",
+      "pinLabel": "PIN",
+      "pinPlaceholder": "输入 4 位 PIN",
+      "pinFormatHint": "PIN 需要是 4 位数字。",
+      "action": "PIN 登录",
+      "pending": "登录中..."
     },
     "reminder": {
       "title": "服务通知",
@@ -926,6 +942,7 @@
     "updateCurrentUserProfileFailed": "更新当前用户资料失败",
     "updateCurrentUserAvatarFailed": "更新当前头像失败",
     "startWechatBindFailed": "发起微信绑定失败",
+    "loginWithPinFailed": "PIN 登录失败",
     "registerLocalAccountFailed": "注册本地账户失败",
     "fetchReimbursementStatusFailed": "获取报销状态失败",
     "verifyBookingContactFailed": "预订联系人手机号授权失败"

--- a/apps/frontend/src/pages/MePage.vue
+++ b/apps/frontend/src/pages/MePage.vue
@@ -29,31 +29,6 @@
         :message="t('mePage.loading')"
       />
 
-      <section
-        v-else-if="!userSessionStore.isAuthenticated"
-        class="surface-card"
-      >
-        <div class="section-header">
-          <div>
-            <h2>{{ t("mePage.register.title") }}</h2>
-            <p>{{ t("mePage.authHint") }}</p>
-          </div>
-        </div>
-
-        <button
-          class="primary-button"
-          type="button"
-          :disabled="registerLocalAccountMutation.isPending.value"
-          @click="handleRegisterLocalAccount"
-        >
-          {{
-            registerLocalAccountMutation.isPending.value
-              ? t("mePage.register.pending")
-              : t("mePage.register.action")
-          }}
-        </button>
-      </section>
-
       <section class="surface-card">
         <div class="section-header">
           <div>
@@ -141,117 +116,214 @@
         </div>
       </section>
 
-      <section class="surface-card">
-        <div class="section-header">
-          <div>
-            <h2>{{ t("mePage.wechat.title") }}</h2>
-            <p>{{ bindHintText }}</p>
-          </div>
-        </div>
-
-        <button
-          class="primary-button"
-          type="button"
-          :disabled="bindActionDisabled"
-          @click="handleStartWeChatBind"
-        >
-          {{
-            startWeChatBindMutation.isPending.value
-              ? t("mePage.wechat.bindingAction")
-              : wechatBound
-                ? t("mePage.wechat.boundAction")
-                : t("mePage.wechat.bindAction")
-          }}
-        </button>
-      </section>
-
-      <WeChatNotificationSubscriptionsCard
-        :title="t('mePage.reminder.title')"
-      >
-        <APRNotificationSubscriptions
-          :updating-label="t('prPage.wechatReminder.updating')"
-          @error-change="handleNotificationPanelErrorChange"
-        />
-      </WeChatNotificationSubscriptionsCard>
-
-      <section class="surface-card">
-        <div class="section-header">
-          <div>
-            <h2>{{ t("mePage.credentials.title") }}</h2>
-            <p>{{ t("mePage.credentials.description") }}</p>
-          </div>
-        </div>
-
-        <div class="credential-list">
-          <div class="credential-item">
-            <div class="credential-copy">
-              <span class="credential-label">{{
-                t("mePage.credentials.userIdLabel")
-              }}</span>
-              <code class="credential-value">{{ storedUserIdLabel }}</code>
+      <template v-if="!userSessionStore.isAuthenticated">
+        <section class="surface-card">
+          <div class="section-header">
+            <div>
+              <h2>{{ t("mePage.wechatLogin.title") }}</h2>
+              <p>{{ wechatLoginHintText }}</p>
             </div>
+          </div>
+
+          <button
+            v-if="isWeChatEnv"
+            class="primary-button"
+            type="button"
+            :disabled="wechatLoginPending"
+            @click="handleStartWeChatLogin"
+          >
+            {{
+              wechatLoginPending
+                ? t("mePage.wechatLogin.pending")
+                : t("mePage.wechatLogin.action")
+            }}
+          </button>
+        </section>
+
+        <section class="surface-card">
+          <div class="section-header">
+            <div>
+              <h2>{{ t("mePage.pinLogin.title") }}</h2>
+              <p>{{ t("mePage.pinLogin.description") }}</p>
+            </div>
+          </div>
+
+          <div class="pin-login-fields">
+            <label class="field">
+              <span class="field__label">{{
+                t("mePage.pinLogin.userIdLabel")
+              }}</span>
+              <input
+                v-model="pinLoginDraft.userId"
+                class="field__input"
+                type="text"
+                :placeholder="t('mePage.pinLogin.userIdPlaceholder')"
+                autocomplete="username"
+                @keydown.enter.prevent="handlePinLogin"
+              />
+            </label>
+
+            <label class="field">
+              <span class="field__label">{{
+                t("mePage.pinLogin.pinLabel")
+              }}</span>
+              <input
+                v-model="pinLoginDraft.userPin"
+                class="field__input"
+                type="password"
+                inputmode="numeric"
+                pattern="[0-9]*"
+                maxlength="4"
+                :placeholder="t('mePage.pinLogin.pinPlaceholder')"
+                autocomplete="one-time-code"
+                @keydown.enter.prevent="handlePinLogin"
+              />
+              <p v-if="showPinFormatHint" class="field__hint">
+                {{ t("mePage.pinLogin.pinFormatHint") }}
+              </p>
+            </label>
+          </div>
+
+          <div class="profile-actions">
+            <button
+              class="primary-button"
+              type="button"
+              :disabled="!canSubmitPinLogin"
+              @click="handlePinLogin"
+            >
+              {{
+                loginWithPinMutation.isPending.value
+                  ? t("mePage.pinLogin.pending")
+                  : t("mePage.pinLogin.action")
+              }}
+            </button>
             <button
               class="secondary-button"
               type="button"
-              :disabled="!storedUserId"
-              @click="handleCopyCredential('userId', storedUserId)"
+              :disabled="registerLocalAccountMutation.isPending.value"
+              @click="handleRegisterLocalAccount"
             >
               {{
-                copiedField === "userId" ? t("common.copied") : t("common.copy")
+                registerLocalAccountMutation.isPending.value
+                  ? t("mePage.register.pending")
+                  : t("mePage.register.action")
               }}
             </button>
           </div>
+        </section>
+      </template>
 
-          <div class="credential-item">
-            <div class="credential-copy">
-              <span class="credential-label">{{
-                t("mePage.credentials.userPinLabel")
-              }}</span>
-              <code class="credential-value">{{ displayedUserPin }}</code>
-            </div>
-            <div class="credential-actions">
-              <button
-                class="secondary-button"
-                type="button"
-                :disabled="!storedUserPin"
-                @click="pinVisible = !pinVisible"
-              >
-                {{
-                  pinVisible
-                    ? t("mePage.credentials.hidePin")
-                    : t("mePage.credentials.showPin")
-                }}
-              </button>
-              <button
-                class="secondary-button"
-                type="button"
-                :disabled="!storedUserPin"
-                @click="handleCopyCredential('userPin', storedUserPin)"
-              >
-                {{
-                  copiedField === "userPin"
-                    ? t("common.copied")
-                    : t("common.copy")
-                }}
-              </button>
+      <template v-else>
+        <section class="surface-card">
+          <div class="section-header">
+            <div>
+              <h2>{{ t("mePage.wechat.title") }}</h2>
+              <p>{{ bindHintText }}</p>
             </div>
           </div>
-        </div>
-      </section>
 
-      <RouterLink class="history-link" :to="{ name: 'pr-mine' }">
-        <div class="history-link__copy">
-          <h2>{{ t("mePage.history.title") }}</h2>
-          <p>{{ t("mePage.history.description") }}</p>
-        </div>
-        <span class="history-link__action">
-          {{ t("mePage.history.action") }}
-          <span
-            class="history-link__icon i-mdi:arrow-right"
-            aria-hidden="true"
-          ></span>
-        </span>
-      </RouterLink>
+          <button
+            class="primary-button"
+            type="button"
+            :disabled="bindActionDisabled"
+            @click="handleStartWeChatBind"
+          >
+            {{
+              startWeChatBindMutation.isPending.value
+                ? t("mePage.wechat.bindingAction")
+                : wechatBound
+                  ? t("mePage.wechat.boundAction")
+                  : t("mePage.wechat.bindAction")
+            }}
+          </button>
+        </section>
+
+        <WeChatNotificationSubscriptionsCard
+          :title="t('mePage.reminder.title')"
+          :items="notificationSubscriptionItems"
+          :updating-label="t('prPage.wechatReminder.updating')"
+          @action="handleNotificationSubscriptionAction"
+        />
+
+        <section class="surface-card">
+          <div class="section-header">
+            <div>
+              <h2>{{ t("mePage.credentials.title") }}</h2>
+              <p>{{ t("mePage.credentials.description") }}</p>
+            </div>
+          </div>
+
+          <div class="credential-list">
+            <div class="credential-item">
+              <div class="credential-copy">
+                <span class="credential-label">{{
+                  t("mePage.credentials.userIdLabel")
+                }}</span>
+                <code class="credential-value">{{ storedUserIdLabel }}</code>
+              </div>
+              <button
+                class="secondary-button"
+                type="button"
+                :disabled="!storedUserId"
+                @click="handleCopyCredential('userId', storedUserId)"
+              >
+                {{
+                  copiedField === "userId" ? t("common.copied") : t("common.copy")
+                }}
+              </button>
+            </div>
+
+            <div class="credential-item">
+              <div class="credential-copy">
+                <span class="credential-label">{{
+                  t("mePage.credentials.userPinLabel")
+                }}</span>
+                <code class="credential-value">{{ displayedUserPin }}</code>
+              </div>
+              <div class="credential-actions">
+                <button
+                  class="secondary-button"
+                  type="button"
+                  :disabled="!storedUserPin"
+                  @click="pinVisible = !pinVisible"
+                >
+                  {{
+                    pinVisible
+                      ? t("mePage.credentials.hidePin")
+                      : t("mePage.credentials.showPin")
+                  }}
+                </button>
+                <button
+                  class="secondary-button"
+                  type="button"
+                  :disabled="!storedUserPin"
+                  @click="handleCopyCredential('userPin', storedUserPin)"
+                >
+                  {{
+                    copiedField === "userPin"
+                      ? t("common.copied")
+                      : t("common.copy")
+                  }}
+                </button>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <RouterLink class="history-link" :to="{ name: 'pr-mine' }">
+          <div class="history-link__copy">
+            <h2>{{ t("mePage.history.title") }}</h2>
+            <p>{{ t("mePage.history.description") }}</p>
+          </div>
+          <span class="history-link__action">
+            {{ t("mePage.history.action") }}
+            <span
+              class="history-link__icon i-mdi:arrow-right"
+              aria-hidden="true"
+            ></span>
+          </span>
+        </RouterLink>
+      </template>
     </div>
 
     <template #footer>
@@ -261,7 +333,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref, watch } from "vue";
+import { computed, reactive, ref, watch } from "vue";
 import { RouterLink, useRoute, useRouter } from "vue-router";
 import { useI18n } from "vue-i18n";
 import LoadingIndicator from "@/shared/ui/feedback/LoadingIndicator.vue";
@@ -270,15 +342,19 @@ import ContactSupportFooter from "@/domains/support/ui/sections/ContactSupportFo
 import PageHeader from "@/shared/ui/navigation/PageHeader.vue";
 import PageScaffoldFlow from "@/shared/ui/layout/PageScaffoldFlow.vue";
 import WeChatNotificationSubscriptionsCard from "@/shared/ui/sections/WeChatNotificationSubscriptionsCard.vue";
-import APRNotificationSubscriptions from "@/shared/ui/sections/APRNotificationSubscriptions.vue";
 import { useUserSessionStore } from "@/shared/auth/useUserSessionStore";
 import { useCurrentUserProfile } from "@/domains/user/queries/useCurrentUserProfile";
 import { useUpdateCurrentUserProfile } from "@/domains/user/queries/useUpdateCurrentUserProfile";
 import { useUpdateCurrentUserAvatar } from "@/domains/user/queries/useUpdateCurrentUserAvatar";
 import { useStartWeChatBind } from "@/domains/user/queries/useStartWeChatBind";
 import { useRegisterLocalAccount } from "@/domains/user/queries/useRegisterLocalAccount";
+import { useLoginWithPin } from "@/domains/user/queries/useLoginWithPin";
+import { useWeChatNotificationSubscriptionsPanel } from "@/shared/wechat/useWeChatNotificationSubscriptionsPanel";
 import { isWeChatBrowser } from "@/shared/browser/isWeChatBrowser";
 import { copyToClipboard } from "@/lib/clipboard";
+import { redirectToWeChatOAuthLogin } from "@/processes/wechat/oauth-login";
+
+const PIN_PATTERN = /^\d{4}$/;
 
 const router = useRouter();
 const route = useRoute();
@@ -290,13 +366,25 @@ const updateProfileMutation = useUpdateCurrentUserProfile();
 const updateAvatarMutation = useUpdateCurrentUserAvatar();
 const startWeChatBindMutation = useStartWeChatBind();
 const registerLocalAccountMutation = useRegisterLocalAccount();
+const loginWithPinMutation = useLoginWithPin();
+const notificationSubscriptions = useWeChatNotificationSubscriptionsPanel({
+  visibleKinds: [
+    "REMINDER_CONFIRMATION",
+    "BOOKING_RESULT",
+    "NEW_PARTNER",
+  ] as const,
+});
 
 const avatarInputRef = ref<HTMLInputElement | null>(null);
 const nicknameDraft = ref("");
 const pinVisible = ref(false);
 const copiedField = ref<"userId" | "userPin" | null>(null);
 const copyErrorMessage = ref<string | null>(null);
-const notificationPanelError = ref<Error | null>(null);
+const wechatLoginPending = ref(false);
+const pinLoginDraft = reactive({
+  userId: "",
+  userPin: "",
+});
 
 const currentUser = computed(() => currentUserQuery.data.value ?? null);
 const canEditProfile = computed(
@@ -316,6 +404,24 @@ const displayedUserPin = computed(() => {
 });
 const isWeChatEnv = computed(() =>
   typeof navigator === "undefined" ? false : isWeChatBrowser(),
+);
+const wechatLoginHintText = computed(() =>
+  isWeChatEnv.value
+    ? t("mePage.wechatLogin.wechatHint")
+    : t("mePage.wechatLogin.nonWechatHint"),
+);
+const normalizedPinLoginUserId = computed(() => pinLoginDraft.userId.trim());
+const normalizedPinLoginPin = computed(() => pinLoginDraft.userPin.trim());
+const showPinFormatHint = computed(
+  () =>
+    normalizedPinLoginPin.value.length > 0 &&
+    !PIN_PATTERN.test(normalizedPinLoginPin.value),
+);
+const canSubmitPinLogin = computed(
+  () =>
+    !loginWithPinMutation.isPending.value &&
+    normalizedPinLoginUserId.value.length > 0 &&
+    PIN_PATTERN.test(normalizedPinLoginPin.value),
 );
 const bindFeedbackCode = computed(() => {
   const raw = route.query.wechatBind;
@@ -352,16 +458,12 @@ const canSaveNickname = computed(() => {
 });
 const bindActionDisabled = computed(
   () =>
-    !userSessionStore.isAuthenticated ||
     currentUser.value === null ||
     wechatBound.value ||
     !isWeChatEnv.value ||
     startWeChatBindMutation.isPending.value,
 );
 const bindHintText = computed(() => {
-  if (!userSessionStore.isAuthenticated) {
-    return t("mePage.wechat.authHint");
-  }
   if (wechatBound.value) {
     return t("mePage.wechat.boundHint");
   }
@@ -371,6 +473,9 @@ const bindHintText = computed(() => {
   return t("mePage.wechat.unboundHint");
 });
 
+const notificationSubscriptionItems = computed(
+  () => notificationSubscriptions.items.value,
+);
 const errorMessage = computed(() => {
   const candidates = [
     currentUserQuery.error.value,
@@ -378,7 +483,8 @@ const errorMessage = computed(() => {
     updateAvatarMutation.error.value,
     startWeChatBindMutation.error.value,
     registerLocalAccountMutation.error.value,
-    notificationPanelError.value,
+    loginWithPinMutation.error.value,
+    notificationSubscriptions.mutation.error.value,
   ];
 
   const firstError = candidates.find((candidate) => candidate instanceof Error);
@@ -419,6 +525,25 @@ const handleAvatarChange = async (event: Event) => {
   }
 };
 
+const handleStartWeChatLogin = () => {
+  if (typeof window === "undefined") return;
+  if (!isWeChatEnv.value || wechatLoginPending.value) return;
+
+  wechatLoginPending.value = true;
+  redirectToWeChatOAuthLogin(window.location.href);
+};
+
+const handlePinLogin = async () => {
+  if (!canSubmitPinLogin.value) return;
+
+  const payload = await loginWithPinMutation.mutateAsync({
+    userId: normalizedPinLoginUserId.value,
+    userPin: normalizedPinLoginPin.value,
+  });
+  userSessionStore.applyAuthSession(payload);
+  pinLoginDraft.userPin = "";
+};
+
 const handleStartWeChatBind = async () => {
   if (bindActionDisabled.value || typeof window === "undefined") return;
 
@@ -433,8 +558,10 @@ const handleRegisterLocalAccount = async () => {
   userSessionStore.applyAuthSession(payload);
 };
 
-const handleNotificationPanelErrorChange = (error: Error | null) => {
-  notificationPanelError.value = error;
+const handleNotificationSubscriptionAction = async (
+  kind: "REMINDER_CONFIRMATION" | "BOOKING_RESULT" | "NEW_PARTNER",
+) => {
+  await notificationSubscriptions.handleAction(kind);
 };
 
 const handleCopyCredential = async (
@@ -499,12 +626,6 @@ const goHome = () => {
 .feedback-banner--error {
   background: var(--sys-color-error-container);
   color: var(--sys-color-on-error-container);
-}
-
-.auth-hint {
-  margin: 0;
-  @include mx.pu-font(body-medium);
-  color: var(--sys-color-on-surface-variant);
 }
 
 .section-header {
@@ -572,10 +693,15 @@ const goHome = () => {
 }
 
 .profile-form,
-.field {
+.field,
+.pin-login-fields {
   display: flex;
   flex-direction: column;
   gap: var(--sys-spacing-sm);
+}
+
+.pin-login-fields {
+  gap: var(--sys-spacing-med);
 }
 
 .field__label {
@@ -585,6 +711,12 @@ const goHome = () => {
 
 .field__input {
   @include mx.pu-field-shell;
+}
+
+.field__hint {
+  margin: 0;
+  @include mx.pu-font(body-small);
+  color: var(--sys-color-on-surface-variant);
 }
 
 .profile-actions,

--- a/apps/frontend/src/processes/wechat/useRouteWeChatAutoLogin.ts
+++ b/apps/frontend/src/processes/wechat/useRouteWeChatAutoLogin.ts
@@ -1,0 +1,104 @@
+import { ref, watch } from "vue";
+import { useRoute } from "vue-router";
+import { useUserSessionStore } from "@/shared/auth/useUserSessionStore";
+import { isWeChatAbilityEnv } from "@/shared/wechat/ability-mocking";
+import { redirectToWeChatOAuthLogin } from "@/processes/wechat/oauth-login";
+
+const AUTO_LOGIN_ROUTE_NAMES = new Set([
+  "anchor-event",
+  "anchor-pr",
+  "anchor-pr-booking-support",
+  "anchor-partner-profile",
+]);
+const AUTO_LOGIN_ATTEMPT_STORAGE_KEY =
+  "partner_up_wechat_auto_login_attempted_routes";
+
+const readAttemptedRouteKeys = (): string[] => {
+  if (typeof window === "undefined") return [];
+
+  try {
+    const raw = window.sessionStorage.getItem(AUTO_LOGIN_ATTEMPT_STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw) as unknown;
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((entry): entry is string => typeof entry === "string");
+  } catch {
+    return [];
+  }
+};
+
+const writeAttemptedRouteKeys = (keys: string[]): void => {
+  if (typeof window === "undefined") return;
+
+  try {
+    window.sessionStorage.setItem(
+      AUTO_LOGIN_ATTEMPT_STORAGE_KEY,
+      JSON.stringify(keys),
+    );
+  } catch {
+    // Ignore sessionStorage write failures.
+  }
+};
+
+const hasRouteAttempted = (routeKey: string): boolean =>
+  readAttemptedRouteKeys().includes(routeKey);
+
+const markRouteAttempted = (routeKey: string): void => {
+  const keys = readAttemptedRouteKeys();
+  if (keys.includes(routeKey)) return;
+  writeAttemptedRouteKeys([...keys, routeKey]);
+};
+
+const clearRouteAttempted = (routeKey: string): void => {
+  const keys = readAttemptedRouteKeys();
+  if (!keys.includes(routeKey)) return;
+  writeAttemptedRouteKeys(keys.filter((entry) => entry !== routeKey));
+};
+
+const resolveAutoLoginRouteKey = (
+  routeName: string | symbol | null | undefined,
+  routePath: string,
+): string | null => {
+  if (typeof routeName !== "string") return null;
+  if (!AUTO_LOGIN_ROUTE_NAMES.has(routeName)) return null;
+  return routePath;
+};
+
+export const useRouteWeChatAutoLogin = () => {
+  const route = useRoute();
+  const userSessionStore = useUserSessionStore();
+  const redirecting = ref(false);
+
+  const attemptAutoLogin = () => {
+    if (typeof window === "undefined") return;
+    if (redirecting.value) return;
+
+    const routeKey = resolveAutoLoginRouteKey(route.name, route.path);
+    if (!routeKey) return;
+
+    if (userSessionStore.isAuthenticated) {
+      clearRouteAttempted(routeKey);
+      return;
+    }
+
+    if (!isWeChatAbilityEnv()) return;
+    if (hasRouteAttempted(routeKey)) return;
+
+    markRouteAttempted(routeKey);
+    redirecting.value = true;
+    redirectToWeChatOAuthLogin(window.location.href);
+  };
+
+  watch(
+    () =>
+      [route.name, route.path, userSessionStore.role, userSessionStore.userId] as const,
+    () => {
+      attemptAutoLogin();
+    },
+    { immediate: true },
+  );
+
+  return {
+    attemptAutoLogin,
+  };
+};

--- a/docs/product/features/user-signin-signup.md
+++ b/docs/product/features/user-signin-signup.md
@@ -16,8 +16,12 @@
   - 否则返回 anonymous 会话（不创建账户）。
 - Admin 登录页调用 `POST /api/auth/admin/login`，使用 `userId + password(PIN)` 登录；后端校验目标用户 `role=service`。
 - 前端将 `user-id`、`user-pin`、`access-token`、`role` 持久化到 localStorage；后续请求自动携带 Bearer token，并通过响应头 `x-access-token` 静默轮换 token。admin 登录不会持久化 PIN。
-- 进入 `/me` 后，前端会展示当前设备保存的 `user-id` 与 `user-pin`，并允许复制；若当前设备尚无本地凭据，则仅展示缺省提示，不自动补发 PIN。
-- `/me` 在 anonymous 状态下提供“直接注册本地账户”按钮，调用 `POST /api/auth/register/local` 立即生成本地用户、PIN 与 Bearer token。
+- 进入 `/me` 后：
+  - anonymous 状态展示「基础资料卡片 + 微信登录卡片 + PIN 登录卡片」，并隐藏需要 authenticated 才可使用的卡片（微信绑定、通知订阅、本地凭据、我的搭子请求）。
+  - 微信登录卡片在微信环境下可触发 `GET /api/wechat/oauth/login` 回流原页面。
+  - PIN 登录卡片通过 `POST /api/auth/session` 提交 `userId + userPin` 恢复本地账户。
+  - anonymous 状态仍可主动调用 `POST /api/auth/register/local` 生成本地用户、PIN 与 Bearer token（入口放在 PIN 登录区）。
+  - authenticated 状态继续展示资料编辑、微信绑定、通知订阅、本地凭据与“我的搭子请求”入口。
 - `/me` 通过以下接口维护当前用户资料：
   - `GET /api/users/me`
   - `PATCH /api/users/me`（`nickname`）
@@ -47,6 +51,8 @@
 - 管理端提供独立 `/admin/login` 登录页，使用 seed 的 admin UUID + PIN 登录。
 - 没有本地凭据且没有微信会话时，`POST /api/auth/session` 返回 anonymous，不创建用户。
 - anonymous 用户可主动调用 `POST /api/auth/register/local` 创建本地账户，无需先发布或加入搭子请求。
+- `/me` 的 anonymous 视图必须包含微信登录与 PIN 登录入口，并隐藏 authenticated 专属卡片（基础资料卡片除外）。
+- PIN 登录成功后，前端会保存会话并恢复 authenticated 视图；PIN 错误时返回明确失败提示。
 - 首次发布 Community PR（`POST /api/cpr/:id/publish`）时，若无登录态则自动创建本地用户并返回 `user-id/user-pin/access-token`。
 - 后续刷新页面时，若 localStorage 中有有效 Bearer token 或 `user-id/user-pin`，可通过 `POST /api/auth/session` 静默恢复 `authenticated/service` 会话。
 - `GET /api/users/me`、`PATCH /api/users/me` 与 `POST /api/users/me/avatar` 仅允许 `authenticated/service` 会话访问。

--- a/docs/product/features/wechat-login.md
+++ b/docs/product/features/wechat-login.md
@@ -9,7 +9,9 @@
 ## 流程
 
 - 用户在微信 WebView 打开任意页面（首页、`/cpr/new`、`/cpr/:id`、`/apr/:id` 等）。
-- 前端不再在页面启动阶段做微信登录前置判断；需要微信身份的动作先直连业务 API。
+- 前端在 Anchor 场景路由（`/events/:eventId`、`/apr/:id`、`/apr/:id/booking-support`、`/apr/:id/partners/:partnerId`）中，若检测到匿名会话 + 微信环境，会在当前 tab 内对同一路径自动尝试一次微信登录。
+- 前端使用 `sessionStorage` 记录已自动尝试的 Anchor 路径，避免用户取消授权或授权失败后反复重定向形成死循环。
+- 除上述 Anchor 场景外，仍由需要微信身份的动作先直连业务 API，再根据错误码触发登录。
 - 后端在动作接口上统一判定微信会话；若未登录则返回 `401 + code=WECHAT_AUTH_REQUIRED`（或 OAuth 未配置返回 `503 + code=WECHAT_OAUTH_NOT_CONFIGURED`）。
 - 前端根据接口返回的 `status + error code` 决定是否重定向到 `GET /api/wechat/oauth/login`，并携带当前页面地址作为 `returnTo`。
 - 后端生成并校验 OAuth state（签名 cookie），跳转微信授权地址（`snsapi_userinfo`）；其中 `redirect_uri` 回调域名优先使用 `FRONTEND_URL`（例如 `https://app.partner-up.cn`），路径为前端专用回调页 `/wechat/oauth/callback`。
@@ -39,7 +41,8 @@
 - OAuth state 与会话 token 均为签名数据，不允许明文可篡改。
 - 已登录用户重复进入页面时不会再次触发授权跳转。
 - 未配置微信 OAuth 所需环境变量时，系统不会进入重定向死循环。
-- 未登录重定向逻辑由业务接口错误码触发，非微信环境不会在页面启动阶段主动跳转。
+- Anchor 场景支持页面进入时自动尝试微信登录，但同一路径在当前 tab 只会自动触发一次；非微信环境不会触发该自动跳转。
+- 其他场景未登录重定向逻辑仍由业务接口错误码触发。
 - 基础环境变量为 `WECHAT_OFFICIAL_ACCOUNT_APP_ID`、`WECHAT_OFFICIAL_ACCOUNT_APP_SECRET`、`WECHAT_AUTH_SESSION_SECRET`。
 
 ## 涉及端


### PR DESCRIPTION
## Summary
- add route-level auto WeChat login for Anchor routes (/events/:eventId, /apr/:id, /apr/:id/booking-support, /apr/:id/partners/:partnerId)
- guard against redirect loops by recording one auto-attempt per route in tab sessionStorage
- refactor /me anonymous experience to show base profile + WeChat login card + PIN login card
- add PIN login mutation backed by POST /api/auth/session
- hide authenticated-only cards on /me when anonymous (bind, subscriptions, credentials, history)
- update related i18n schema/zh-CN copy and product docs

## Verification
- pnpm --filter @partner-up-dev/frontend build

Closes #45