### PR TITLE
fix(wechat): include page target in subscribe notification bizsend

### DIFF
--- a/apps/backend/src/infra/notifications/wechat-reminder.ts
+++ b/apps/backend/src/infra/notifications/wechat-reminder.ts
@@ -326,12 +326,14 @@ async function handleReminderJob(
 
   try {
     if (submsgConfigured) {
+      const prPage = resolvePrUrl(request);
       await subscriptionMessageService.sendConfirmationReminder({
         openId: user.openId,
         orderContent: resolveReminderTitle(request),
         orderNo: resolveReminderOrderNo(request, user.id),
         appointmentAt: formatReminderDateField(startAt),
         remark: resolveReminderRemark(payload.reminderType),
+        page: prPage,
       });
     } else {
       await templateService.sendReminderTemplate({
@@ -491,6 +493,7 @@ async function handleNewPartnerJob(
 
   const joinedUser = await userRepo.findById(payload.joinedUserId);
   const applicantName = resolveApplicantName(joinedUser?.nickname ?? null);
+  const prPage = resolvePrUrl(request);
 
   try {
     await subscriptionMessageService.sendNewPartnerNotification({
@@ -499,6 +502,7 @@ async function handleNewPartnerJob(
       teamName: resolveTeamName(request),
       tip: NEW_PARTNER_TIP,
       appliedAt: formatAppliedAt(payload.joinedAtIso),
+      page: prPage,
     });
   } catch (error) {
     const classified = classifyNewPartnerError(error);

--- a/apps/backend/src/services/WeChatSubscriptionMessageService.ts
+++ b/apps/backend/src/services/WeChatSubscriptionMessageService.ts
@@ -54,6 +54,7 @@ export interface SendConfirmationReminderParams {
   orderNo: string;
   appointmentAt: string;
   remark: string;
+  page: string | null;
 }
 
 export interface SendNewPartnerNotificationParams {
@@ -62,6 +63,7 @@ export interface SendNewPartnerNotificationParams {
   teamName: string;
   tip: string;
   appliedAt: string;
+  page: string | null;
 }
 
 const clipText = (value: string, max: number): string =>
@@ -199,6 +201,7 @@ export class WeChatSubscriptionMessageService {
       body: JSON.stringify({
         touser: params.openId,
         template_id: templateId,
+        page: params.page ?? undefined,
         miniprogram_state: "formal",
         lang: "zh_CN",
         data: {
@@ -244,6 +247,7 @@ export class WeChatSubscriptionMessageService {
       body: JSON.stringify({
         touser: params.openId,
         template_id: templateId,
+        page: params.page ?? undefined,
         miniprogram_state: "formal",
         lang: "zh_CN",
         data: {


### PR DESCRIPTION
## Summary
- add optional page field support to service-account subscribe bizsend payloads
- wire notification jump target from existing PR detail URL resolver (/apr/:id / /cpr/:id)
- apply to both REMINDER_CONFIRMATION and NEW_PARTNER sends

## Why
Notification delivery worked, but users could not click through to the target page because bizsend payload omitted page.

## Validation
- pnpm --filter @partner-up-dev/backend build

Ref: #36