### PR TITLE
fix(frontend): avoid OAuth history pollution on WeChat login

### DIFF
--- a/apps/frontend/src/processes/wechat/oauth-login.ts
+++ b/apps/frontend/src/processes/wechat/oauth-login.ts
@@ -15,7 +15,7 @@ export const resolveOAuthLoginUrl = (returnTo: string): string => {
 
 export const redirectToWeChatOAuthLogin = (returnTo: string): void => {
   if (typeof window === "undefined") return;
-  window.location.assign(resolveOAuthLoginUrl(returnTo));
+  window.location.replace(resolveOAuthLoginUrl(returnTo));
 };
 
 export const redirectToWeChatOAuthBind = async (
@@ -46,5 +46,5 @@ export const redirectToWeChatOAuthBind = async (
     return;
   }
 
-  window.location.assign(payload.authorizeUrl);
+  window.location.replace(payload.authorizeUrl);
 };


### PR DESCRIPTION
## Summary
- switch WeChat OAuth entry redirects from location.assign to location.replace
- apply to both login and bind entry flows
- keep callback return behavior as replace (already in place)

## Why
- prevent OAuth intermediate pages from polluting browser history and degrading back navigation experience after successful login

## Verification
- pnpm --filter @partner-up-dev/frontend build


Refs #45