### PR TITLE
feat(wechat): move notification subscriptions to credit quota

### DIFF
--- a/apps/backend/drizzle/0009_user_notification_opt_remaining_counts.sql
+++ b/apps/backend/drizzle/0009_user_notification_opt_remaining_counts.sql
@@ -1,0 +1,23 @@
+alter table "user_notification_opts"
+  add column if not exists "wechat_reminder_remaining_count" integer not null default 0;
+
+alter table "user_notification_opts"
+  add column if not exists "wechat_booking_result_remaining_count" integer not null default 0;
+
+alter table "user_notification_opts"
+  add column if not exists "wechat_new_partner_remaining_count" integer not null default 0;
+
+update "user_notification_opts"
+set
+  "wechat_reminder_remaining_count" = case
+    when "wechat_reminder_opt_in" then 1
+    else 0
+  end,
+  "wechat_booking_result_remaining_count" = case
+    when "wechat_booking_result_opt_in" then 1
+    else 0
+  end,
+  "wechat_new_partner_remaining_count" = case
+    when "wechat_new_partner_opt_in" then 1
+    else 0
+  end;

--- a/apps/backend/src/controllers/wechat.controller.ts
+++ b/apps/backend/src/controllers/wechat.controller.ts
@@ -86,9 +86,10 @@ const oauthStateCookiePayloadSchema = z.object({
 const reminderSubscriptionUpdateSchema = z.object({
   enabled: z.boolean(),
 });
+const notificationSubscriptionActionSchema = z.enum(["ADD_ONE", "CLEAR"]);
 const notificationSubscriptionUpdateSchema = z.object({
   kind: wechatNotificationKindSchema,
-  enabled: z.boolean(),
+  action: notificationSubscriptionActionSchema,
 });
 const resolvePhoneSchema = z.object({
   credential: z.string().trim().min(1),
@@ -99,6 +100,7 @@ type OAuthStateMode = OAuthStateCookiePayload["mode"];
 type NotificationSubscriptionState = {
   enabled: boolean;
   optInAt: string | null;
+  remainingCount: number;
   configured: boolean;
   requiresOpenSubscribe: boolean;
   templateId: string | null;
@@ -133,14 +135,21 @@ const buildNotificationChannelState = async (): Promise<{
     "configured" | "requiresOpenSubscribe" | "templateId"
   >;
 }> => {
-  const [reminderTemplateId, newPartnerTemplateId] = await Promise.all([
-    subscriptionMessageService.getConfirmationReminderTemplateId(),
-    subscriptionMessageService.getNewPartnerTemplateId(),
-  ]);
+  const [reminderTemplateId, bookingResultTemplateId, newPartnerTemplateId] =
+    await Promise.all([
+      subscriptionMessageService.getConfirmationReminderTemplateId(),
+      subscriptionMessageService.getBookingResultTemplateId(),
+      subscriptionMessageService.getNewPartnerTemplateId(),
+    ]);
 
-  const [reminderSubmsgConfigured, newPartnerSubmsgConfigured] =
+  const [
+    reminderSubmsgConfigured,
+    bookingResultSubmsgConfigured,
+    newPartnerSubmsgConfigured,
+  ] =
     await Promise.all([
       subscriptionMessageService.isConfirmationReminderConfigured(),
+      subscriptionMessageService.isBookingResultConfigured(),
       subscriptionMessageService.isNewPartnerConfigured(),
     ]);
 
@@ -153,9 +162,10 @@ const buildNotificationChannelState = async (): Promise<{
       templateId: reminderTemplateId,
     },
     bookingResult: {
-      configured: true,
-      requiresOpenSubscribe: false,
-      templateId: null,
+      configured: bookingResultSubmsgConfigured,
+      requiresOpenSubscribe:
+        bookingResultSubmsgConfigured && Boolean(bookingResultTemplateId),
+      templateId: bookingResultTemplateId,
     },
     newPartner: {
       configured: newPartnerSubmsgConfigured,
@@ -177,6 +187,7 @@ const buildAnonymousSubscriptionsResponse = async (configured: boolean) => {
       REMINDER_CONFIRMATION: {
         enabled: false,
         optInAt: null,
+        remainingCount: 0,
         configured: channels.reminder.configured,
         requiresOpenSubscribe: channels.reminder.requiresOpenSubscribe,
         templateId: channels.reminder.templateId,
@@ -184,6 +195,7 @@ const buildAnonymousSubscriptionsResponse = async (configured: boolean) => {
       BOOKING_RESULT: {
         enabled: false,
         optInAt: null,
+        remainingCount: 0,
         configured: channels.bookingResult.configured,
         requiresOpenSubscribe: channels.bookingResult.requiresOpenSubscribe,
         templateId: channels.bookingResult.templateId,
@@ -191,6 +203,7 @@ const buildAnonymousSubscriptionsResponse = async (configured: boolean) => {
       NEW_PARTNER: {
         enabled: false,
         optInAt: null,
+        remainingCount: 0,
         configured: channels.newPartner.configured,
         requiresOpenSubscribe: channels.newPartner.requiresOpenSubscribe,
         templateId: channels.newPartner.templateId,
@@ -231,6 +244,7 @@ const buildAuthenticatedSubscriptionsResponse = async (
       REMINDER_CONFIRMATION: {
         enabled: reminder.enabled,
         optInAt: reminder.optInAt ? reminder.optInAt.toISOString() : null,
+        remainingCount: reminder.remainingCount,
         configured: channels.reminder.configured,
         requiresOpenSubscribe: channels.reminder.requiresOpenSubscribe,
         templateId: channels.reminder.templateId,
@@ -240,6 +254,7 @@ const buildAuthenticatedSubscriptionsResponse = async (
         optInAt: bookingResult.optInAt
           ? bookingResult.optInAt.toISOString()
           : null,
+        remainingCount: bookingResult.remainingCount,
         configured: channels.bookingResult.configured,
         requiresOpenSubscribe: channels.bookingResult.requiresOpenSubscribe,
         templateId: channels.bookingResult.templateId,
@@ -247,6 +262,7 @@ const buildAuthenticatedSubscriptionsResponse = async (
       NEW_PARTNER: {
         enabled: newPartner.enabled,
         optInAt: newPartner.optInAt ? newPartner.optInAt.toISOString() : null,
+        remainingCount: newPartner.remainingCount,
         configured: channels.newPartner.configured,
         requiresOpenSubscribe: channels.newPartner.requiresOpenSubscribe,
         templateId: channels.newPartner.templateId,
@@ -258,17 +274,21 @@ const buildAuthenticatedSubscriptionsResponse = async (
 const applyNotificationSubscriptionSideEffects = async (
   userId: UserId,
   kind: WeChatNotificationKind,
-  enabled: boolean,
+  previousRemainingCount: number,
+  nextRemainingCount: number,
 ): Promise<number> => {
   if (kind === "REMINDER_CONFIRMATION") {
-    if (enabled) {
+    if (nextRemainingCount <= 0) {
+      return cancelWeChatReminderJobsForUser(userId);
+    }
+    if (previousRemainingCount <= 0 && nextRemainingCount > 0) {
       await rebuildWeChatReminderJobsForUser(userId);
       return 0;
     }
-    return cancelWeChatReminderJobsForUser(userId);
+    return 0;
   }
 
-  if (kind === "NEW_PARTNER" && !enabled) {
+  if (kind === "NEW_PARTNER" && nextRemainingCount <= 0) {
     return cancelWeChatNewPartnerJobsForUser(userId);
   }
 
@@ -711,13 +731,24 @@ export const wechatRoute = app
         return c.json(identity.payload, identity.status);
       }
 
-      const { kind, enabled } = c.req.valid("json");
+      const { kind, action } = c.req.valid("json");
+      const currentNotificationOpt = await userNotificationOptRepo.findByUserId(
+        identity.user.id,
+      );
+      const previousSnapshot = userNotificationOptRepo.getSubscriptionSnapshot(
+        currentNotificationOpt,
+        kind,
+      );
       const updatedNotificationOpt =
-        await userNotificationOptRepo.upsertWechatNotificationSubscription(
-          identity.user.id,
-          kind,
-          enabled,
-        );
+        action === "ADD_ONE"
+          ? await userNotificationOptRepo.addOneWechatNotificationCredit(
+              identity.user.id,
+              kind,
+            )
+          : await userNotificationOptRepo.clearWechatNotificationCredits(
+              identity.user.id,
+              kind,
+            );
       if (!updatedNotificationOpt) {
         return c.json(
           { error: "Failed to update notification subscription" },
@@ -731,7 +762,8 @@ export const wechatRoute = app
       const deletedJobs = await applyNotificationSubscriptionSideEffects(
         identity.user.id,
         kind,
-        enabled,
+        previousSnapshot.remainingCount,
+        snapshot.remainingCount,
       );
       const fullState = await buildAuthenticatedSubscriptionsResponse(
         identity.user.id,
@@ -740,8 +772,10 @@ export const wechatRoute = app
       return c.json({
         ok: true,
         kind,
+        action,
         enabled: snapshot.enabled,
         optInAt: snapshot.optInAt ? snapshot.optInAt.toISOString() : null,
+        remainingCount: snapshot.remainingCount,
         configured: selectedState.configured,
         deletedJobs,
       });
@@ -757,6 +791,7 @@ export const wechatRoute = app
         wechatBound: fallback.wechatBound,
         enabled: reminder.enabled,
         optInAt: reminder.optInAt,
+        remainingCount: reminder.remainingCount,
       });
     }
 
@@ -772,6 +807,7 @@ export const wechatRoute = app
         wechatBound: false,
         enabled: reminder.enabled,
         optInAt: reminder.optInAt,
+        remainingCount: reminder.remainingCount,
       });
     }
 
@@ -786,6 +822,7 @@ export const wechatRoute = app
       wechatBound: fullState.wechatBound,
       enabled: reminder.enabled,
       optInAt: reminder.optInAt,
+      remainingCount: reminder.remainingCount,
     });
   })
   .post(
@@ -802,11 +839,18 @@ export const wechatRoute = app
       }
 
       const { enabled } = c.req.valid("json");
+      const currentNotificationOpt = await userNotificationOptRepo.findByUserId(
+        identity.user.id,
+      );
+      const previousSnapshot = userNotificationOptRepo.getSubscriptionSnapshot(
+        currentNotificationOpt,
+        "REMINDER_CONFIRMATION",
+      );
       const updatedNotificationOpt =
-        await userNotificationOptRepo.upsertWechatNotificationSubscription(
+        await userNotificationOptRepo.setWechatNotificationRemainingCount(
           identity.user.id,
           "REMINDER_CONFIRMATION",
-          enabled,
+          enabled ? 1 : 0,
         );
       if (!updatedNotificationOpt) {
         return c.json({ error: "Failed to update reminder subscription" }, 500);
@@ -818,7 +862,8 @@ export const wechatRoute = app
       const deletedJobs = await applyNotificationSubscriptionSideEffects(
         identity.user.id,
         "REMINDER_CONFIRMATION",
-        enabled,
+        previousSnapshot.remainingCount,
+        snapshot.remainingCount,
       );
       const fullState = await buildAuthenticatedSubscriptionsResponse(
         identity.user.id,
@@ -829,6 +874,7 @@ export const wechatRoute = app
         ok: true,
         enabled: snapshot.enabled,
         optInAt: snapshot.optInAt ? snapshot.optInAt.toISOString() : null,
+        remainingCount: snapshot.remainingCount,
         configured: fullState.configured && reminder.configured,
         deletedJobs,
       });

--- a/apps/backend/src/entities/user-notification-opt.ts
+++ b/apps/backend/src/entities/user-notification-opt.ts
@@ -1,4 +1,4 @@
-import { boolean, pgTable, timestamp, uuid } from "drizzle-orm/pg-core";
+import { boolean, integer, pgTable, timestamp, uuid } from "drizzle-orm/pg-core";
 import { createInsertSchema, createSelectSchema } from "drizzle-zod";
 import { z } from "zod";
 import { users, type UserId } from "./user";
@@ -21,14 +21,25 @@ export const userNotificationOpts = pgTable("user_notification_opts", {
     .notNull()
     .default(false),
   wechatReminderOptInAt: timestamp("wechat_reminder_opt_in_at"),
+  wechatReminderRemainingCount: integer("wechat_reminder_remaining_count")
+    .notNull()
+    .default(0),
   wechatBookingResultOptIn: boolean("wechat_booking_result_opt_in")
     .notNull()
     .default(false),
   wechatBookingResultOptInAt: timestamp("wechat_booking_result_opt_in_at"),
+  wechatBookingResultRemainingCount: integer(
+    "wechat_booking_result_remaining_count",
+  )
+    .notNull()
+    .default(0),
   wechatNewPartnerOptIn: boolean("wechat_new_partner_opt_in")
     .notNull()
     .default(false),
   wechatNewPartnerOptInAt: timestamp("wechat_new_partner_opt_in_at"),
+  wechatNewPartnerRemainingCount: integer("wechat_new_partner_remaining_count")
+    .notNull()
+    .default(0),
   createdAt: timestamp("created_at").notNull().defaultNow(),
   updatedAt: timestamp("updated_at").notNull().defaultNow(),
 });

--- a/apps/backend/src/infra/notifications/wechat-reminder.ts
+++ b/apps/backend/src/infra/notifications/wechat-reminder.ts
@@ -251,7 +251,11 @@ async function handleReminderJob(
   }
 
   const notificationOpt = await userNotificationOptRepo.findByUserId(user.id);
-  if (!notificationOpt?.wechatReminderOptIn) {
+  const reminderSnapshot = userNotificationOptRepo.getSubscriptionSnapshot(
+    notificationOpt,
+    "REMINDER_CONFIRMATION",
+  );
+  if (!reminderSnapshot.enabled) {
     await recordDelivery({
       jobId: context.jobId,
       payload,
@@ -351,13 +355,20 @@ async function handleReminderJob(
       payload,
       result: "SUCCESS",
     });
+    const consumeResult =
+      await userNotificationOptRepo.consumeOneWechatNotificationCredit(
+        user.id,
+        "REMINDER_CONFIRMATION",
+      );
+    if (consumeResult.consumed && consumeResult.remainingCount <= 0) {
+      await cancelWeChatReminderJobsForUser(user.id);
+    }
   } catch (error) {
     const classified = classifyReminderError(error);
     if (classified.code === "43101") {
-      await userNotificationOptRepo.upsertWechatNotificationSubscription(
+      await userNotificationOptRepo.clearWechatNotificationCredits(
         user.id,
         "REMINDER_CONFIRMATION",
-        false,
       );
       await cancelWeChatReminderJobsForUser(user.id);
     }
@@ -389,7 +400,11 @@ export async function scheduleWeChatReminderJobsForParticipant(
   const notificationOpt = user
     ? await userNotificationOptRepo.findByUserId(userId)
     : null;
-  if (!user || !notificationOpt?.wechatReminderOptIn) {
+  const reminderSnapshot = userNotificationOptRepo.getSubscriptionSnapshot(
+    notificationOpt,
+    "REMINDER_CONFIRMATION",
+  );
+  if (!user || !reminderSnapshot.enabled) {
     return;
   }
 
@@ -504,13 +519,20 @@ async function handleNewPartnerJob(
       appliedAt: formatAppliedAt(payload.joinedAtIso),
       page: prPage,
     });
+    const consumeResult =
+      await userNotificationOptRepo.consumeOneWechatNotificationCredit(
+        recipient.id,
+        "NEW_PARTNER",
+      );
+    if (consumeResult.consumed && consumeResult.remainingCount <= 0) {
+      await cancelWeChatNewPartnerJobsForUser(recipient.id);
+    }
   } catch (error) {
     const classified = classifyNewPartnerError(error);
     if (classified.code === "43101") {
-      await userNotificationOptRepo.upsertWechatNotificationSubscription(
+      await userNotificationOptRepo.clearWechatNotificationCredits(
         recipient.id,
         "NEW_PARTNER",
-        false,
       );
       await cancelWeChatNewPartnerJobsForUser(recipient.id);
     }

--- a/apps/backend/src/repositories/UserNotificationOptRepository.ts
+++ b/apps/backend/src/repositories/UserNotificationOptRepository.ts
@@ -1,4 +1,4 @@
-import { eq } from "drizzle-orm";
+import { and, eq, gt, sql } from "drizzle-orm";
 import { db } from "../lib/db";
 import {
   userNotificationOpts,
@@ -10,6 +10,18 @@ import type { UserId } from "../entities/user";
 export type NotificationSubscriptionSnapshot = {
   enabled: boolean;
   optInAt: Date | null;
+  remainingCount: number;
+};
+
+export type ConsumeNotificationCreditResult = {
+  consumed: boolean;
+  remainingCount: number;
+  row: UserNotificationOpt | null;
+};
+
+const normalizeRemainingCount = (value: number): number => {
+  if (!Number.isFinite(value)) return 0;
+  return Math.max(0, Math.trunc(value));
 };
 
 export class UserNotificationOptRepository {
@@ -40,24 +52,28 @@ export class UserNotificationOptRepository {
       return {
         enabled: false,
         optInAt: null,
+        remainingCount: 0,
       };
     }
 
     if (kind === "REMINDER_CONFIRMATION") {
       return {
-        enabled: opt.wechatReminderOptIn,
+        enabled: opt.wechatReminderRemainingCount > 0,
         optInAt: opt.wechatReminderOptInAt,
+        remainingCount: opt.wechatReminderRemainingCount,
       };
     }
     if (kind === "BOOKING_RESULT") {
       return {
-        enabled: opt.wechatBookingResultOptIn,
+        enabled: opt.wechatBookingResultRemainingCount > 0,
         optInAt: opt.wechatBookingResultOptInAt,
+        remainingCount: opt.wechatBookingResultRemainingCount,
       };
     }
     return {
-      enabled: opt.wechatNewPartnerOptIn,
+      enabled: opt.wechatNewPartnerRemainingCount > 0,
       optInAt: opt.wechatNewPartnerOptInAt,
+      remainingCount: opt.wechatNewPartnerRemainingCount,
     };
   }
 
@@ -66,7 +82,17 @@ export class UserNotificationOptRepository {
     kind: WeChatNotificationKind,
     enabled: boolean,
   ): Promise<UserNotificationOpt | null> {
+    return this.setWechatNotificationRemainingCount(userId, kind, enabled ? 1 : 0);
+  }
+
+  async setWechatNotificationRemainingCount(
+    userId: UserId,
+    kind: WeChatNotificationKind,
+    remainingCount: number,
+  ): Promise<UserNotificationOpt | null> {
     const now = new Date();
+    const normalizedCount = normalizeRemainingCount(remainingCount);
+    const enabled = normalizedCount > 0;
     const optInAt = enabled ? now : null;
 
     if (kind === "REMINDER_CONFIRMATION") {
@@ -74,6 +100,7 @@ export class UserNotificationOptRepository {
         .insert(userNotificationOpts)
         .values({
           userId,
+          wechatReminderRemainingCount: normalizedCount,
           wechatReminderOptIn: enabled,
           wechatReminderOptInAt: optInAt,
           updatedAt: now,
@@ -81,6 +108,7 @@ export class UserNotificationOptRepository {
         .onConflictDoUpdate({
           target: userNotificationOpts.userId,
           set: {
+            wechatReminderRemainingCount: normalizedCount,
             wechatReminderOptIn: enabled,
             wechatReminderOptInAt: optInAt,
             updatedAt: now,
@@ -95,6 +123,7 @@ export class UserNotificationOptRepository {
         .insert(userNotificationOpts)
         .values({
           userId,
+          wechatBookingResultRemainingCount: normalizedCount,
           wechatBookingResultOptIn: enabled,
           wechatBookingResultOptInAt: optInAt,
           updatedAt: now,
@@ -102,6 +131,7 @@ export class UserNotificationOptRepository {
         .onConflictDoUpdate({
           target: userNotificationOpts.userId,
           set: {
+            wechatBookingResultRemainingCount: normalizedCount,
             wechatBookingResultOptIn: enabled,
             wechatBookingResultOptInAt: optInAt,
             updatedAt: now,
@@ -115,6 +145,7 @@ export class UserNotificationOptRepository {
       .insert(userNotificationOpts)
       .values({
         userId,
+        wechatNewPartnerRemainingCount: normalizedCount,
         wechatNewPartnerOptIn: enabled,
         wechatNewPartnerOptInAt: optInAt,
         updatedAt: now,
@@ -122,6 +153,7 @@ export class UserNotificationOptRepository {
       .onConflictDoUpdate({
         target: userNotificationOpts.userId,
         set: {
+          wechatNewPartnerRemainingCount: normalizedCount,
           wechatNewPartnerOptIn: enabled,
           wechatNewPartnerOptInAt: optInAt,
           updatedAt: now,
@@ -129,5 +161,163 @@ export class UserNotificationOptRepository {
       })
       .returning();
     return result[0] ?? null;
+  }
+
+  async addOneWechatNotificationCredit(
+    userId: UserId,
+    kind: WeChatNotificationKind,
+  ): Promise<UserNotificationOpt | null> {
+    const now = new Date();
+
+    if (kind === "REMINDER_CONFIRMATION") {
+      const result = await db
+        .insert(userNotificationOpts)
+        .values({
+          userId,
+          wechatReminderRemainingCount: 1,
+          wechatReminderOptIn: true,
+          wechatReminderOptInAt: now,
+          updatedAt: now,
+        })
+        .onConflictDoUpdate({
+          target: userNotificationOpts.userId,
+          set: {
+            wechatReminderRemainingCount: sql`${userNotificationOpts.wechatReminderRemainingCount} + 1`,
+            wechatReminderOptIn: true,
+            wechatReminderOptInAt: now,
+            updatedAt: now,
+          },
+        })
+        .returning();
+      return result[0] ?? null;
+    }
+
+    if (kind === "BOOKING_RESULT") {
+      const result = await db
+        .insert(userNotificationOpts)
+        .values({
+          userId,
+          wechatBookingResultRemainingCount: 1,
+          wechatBookingResultOptIn: true,
+          wechatBookingResultOptInAt: now,
+          updatedAt: now,
+        })
+        .onConflictDoUpdate({
+          target: userNotificationOpts.userId,
+          set: {
+            wechatBookingResultRemainingCount: sql`${userNotificationOpts.wechatBookingResultRemainingCount} + 1`,
+            wechatBookingResultOptIn: true,
+            wechatBookingResultOptInAt: now,
+            updatedAt: now,
+          },
+        })
+        .returning();
+      return result[0] ?? null;
+    }
+
+    const result = await db
+      .insert(userNotificationOpts)
+      .values({
+        userId,
+        wechatNewPartnerRemainingCount: 1,
+        wechatNewPartnerOptIn: true,
+        wechatNewPartnerOptInAt: now,
+        updatedAt: now,
+      })
+      .onConflictDoUpdate({
+        target: userNotificationOpts.userId,
+        set: {
+          wechatNewPartnerRemainingCount: sql`${userNotificationOpts.wechatNewPartnerRemainingCount} + 1`,
+          wechatNewPartnerOptIn: true,
+          wechatNewPartnerOptInAt: now,
+          updatedAt: now,
+        },
+      })
+      .returning();
+    return result[0] ?? null;
+  }
+
+  async clearWechatNotificationCredits(
+    userId: UserId,
+    kind: WeChatNotificationKind,
+  ): Promise<UserNotificationOpt | null> {
+    return this.setWechatNotificationRemainingCount(userId, kind, 0);
+  }
+
+  async consumeOneWechatNotificationCredit(
+    userId: UserId,
+    kind: WeChatNotificationKind,
+  ): Promise<ConsumeNotificationCreditResult> {
+    const now = new Date();
+
+    if (kind === "REMINDER_CONFIRMATION") {
+      const result = await db
+        .update(userNotificationOpts)
+        .set({
+          wechatReminderRemainingCount: sql`${userNotificationOpts.wechatReminderRemainingCount} - 1`,
+          wechatReminderOptIn: sql`(${userNotificationOpts.wechatReminderRemainingCount} - 1) > 0`,
+          wechatReminderOptInAt: sql`case when (${userNotificationOpts.wechatReminderRemainingCount} - 1) > 0 then ${userNotificationOpts.wechatReminderOptInAt} else null end`,
+          updatedAt: now,
+        })
+        .where(
+          and(
+            eq(userNotificationOpts.userId, userId),
+            gt(userNotificationOpts.wechatReminderRemainingCount, 0),
+          ),
+        )
+        .returning();
+      const row = result[0] ?? null;
+      return {
+        consumed: row !== null,
+        remainingCount: row?.wechatReminderRemainingCount ?? 0,
+        row,
+      };
+    }
+
+    if (kind === "BOOKING_RESULT") {
+      const result = await db
+        .update(userNotificationOpts)
+        .set({
+          wechatBookingResultRemainingCount: sql`${userNotificationOpts.wechatBookingResultRemainingCount} - 1`,
+          wechatBookingResultOptIn: sql`(${userNotificationOpts.wechatBookingResultRemainingCount} - 1) > 0`,
+          wechatBookingResultOptInAt: sql`case when (${userNotificationOpts.wechatBookingResultRemainingCount} - 1) > 0 then ${userNotificationOpts.wechatBookingResultOptInAt} else null end`,
+          updatedAt: now,
+        })
+        .where(
+          and(
+            eq(userNotificationOpts.userId, userId),
+            gt(userNotificationOpts.wechatBookingResultRemainingCount, 0),
+          ),
+        )
+        .returning();
+      const row = result[0] ?? null;
+      return {
+        consumed: row !== null,
+        remainingCount: row?.wechatBookingResultRemainingCount ?? 0,
+        row,
+      };
+    }
+
+    const result = await db
+      .update(userNotificationOpts)
+      .set({
+        wechatNewPartnerRemainingCount: sql`${userNotificationOpts.wechatNewPartnerRemainingCount} - 1`,
+        wechatNewPartnerOptIn: sql`(${userNotificationOpts.wechatNewPartnerRemainingCount} - 1) > 0`,
+        wechatNewPartnerOptInAt: sql`case when (${userNotificationOpts.wechatNewPartnerRemainingCount} - 1) > 0 then ${userNotificationOpts.wechatNewPartnerOptInAt} else null end`,
+        updatedAt: now,
+      })
+      .where(
+        and(
+          eq(userNotificationOpts.userId, userId),
+          gt(userNotificationOpts.wechatNewPartnerRemainingCount, 0),
+        ),
+      )
+      .returning();
+    const row = result[0] ?? null;
+    return {
+      consumed: row !== null,
+      remainingCount: row?.wechatNewPartnerRemainingCount ?? 0,
+      row,
+    };
   }
 }

--- a/apps/backend/src/services/WeChatSubscriptionMessageService.ts
+++ b/apps/backend/src/services/WeChatSubscriptionMessageService.ts
@@ -31,10 +31,15 @@ const subscribeSendResponseSchema = z.object({
 
 const CONFIG_KEY_WECHAT_SUBMSG_CONFIRMATION_REMINDER_TEMPLATE_ID =
   "wechat.submsg_confirmation_reminder_template_id";
+const CONFIG_KEY_WECHAT_SUBMSG_BOOKING_RESULT_TEMPLATE_ID =
+  "wechat.submsg_booking_result_template_id";
 const CONFIG_KEY_WECHAT_SUBMSG_NEW_PARTNER_TEMPLATE_ID =
   "wechat.submsg_new_partner_template_id";
 
-type SubscriptionTemplateKind = "REMINDER_CONFIRMATION" | "NEW_PARTNER";
+type SubscriptionTemplateKind =
+  | "REMINDER_CONFIRMATION"
+  | "BOOKING_RESULT"
+  | "NEW_PARTNER";
 
 export class WeChatSubscriptionMessageError extends Error {
   constructor(
@@ -80,12 +85,20 @@ export class WeChatSubscriptionMessageService {
     return this.isConfigured("REMINDER_CONFIRMATION");
   }
 
+  async isBookingResultConfigured(): Promise<boolean> {
+    return this.isConfigured("BOOKING_RESULT");
+  }
+
   async isNewPartnerConfigured(): Promise<boolean> {
     return this.isConfigured("NEW_PARTNER");
   }
 
   async getConfirmationReminderTemplateId(): Promise<string | null> {
     return this.resolveTemplateId("REMINDER_CONFIRMATION");
+  }
+
+  async getBookingResultTemplateId(): Promise<string | null> {
+    return this.resolveTemplateId("BOOKING_RESULT");
   }
 
   async getNewPartnerTemplateId(): Promise<string | null> {
@@ -107,6 +120,8 @@ export class WeChatSubscriptionMessageService {
     const configKey =
       kind === "REMINDER_CONFIRMATION"
         ? CONFIG_KEY_WECHAT_SUBMSG_CONFIRMATION_REMINDER_TEMPLATE_ID
+        : kind === "BOOKING_RESULT"
+          ? CONFIG_KEY_WECHAT_SUBMSG_BOOKING_RESULT_TEMPLATE_ID
         : CONFIG_KEY_WECHAT_SUBMSG_NEW_PARTNER_TEMPLATE_ID;
 
     const configuredTemplateId = await this.configService.getValue(configKey);
@@ -133,6 +148,8 @@ export class WeChatSubscriptionMessageService {
       const templateKey =
         kind === "REMINDER_CONFIRMATION"
           ? "wechat.submsg_confirmation_reminder_template_id"
+          : kind === "BOOKING_RESULT"
+            ? "wechat.submsg_booking_result_template_id"
           : "wechat.submsg_new_partner_template_id";
       throw new Error(`Missing config: ${templateKey}`);
     }

--- a/apps/frontend/src/locales/schema.ts
+++ b/apps/frontend/src/locales/schema.ts
@@ -317,6 +317,8 @@ export interface MessageSchema {
     };
     notificationSubscriptions: {
       title: string;
+      subscribeOnceAction: string;
+      remainingCountWithHint: string;
       openSubscribeUnavailableHint: string;
       items: {
         REMINDER_CONFIRMATION: {

--- a/apps/frontend/src/locales/zh-CN.jsonc
+++ b/apps/frontend/src/locales/zh-CN.jsonc
@@ -336,22 +336,24 @@
     },
     "notificationSubscriptions": {
       "title": "通知订阅",
+      "subscribeOnceAction": "订阅 1 次",
+      "remainingCountWithHint": "剩余通知次数：{count}。{hint}",
       "openSubscribeUnavailableHint": "当前微信订阅组件不可用，请升级微信后重试。",
       "items": {
         "REMINDER_CONFIRMATION": {
           "title": "确认席位提醒",
-          "enabledHint": "已开启确认席位提醒：活动前 24 小时和 2 小时会发送通知。",
-          "disabledHint": "确认席位提醒已关闭，可随时开启。"
+          "enabledHint": "你可继续接收确认席位提醒（活动前 24 小时和 2 小时）。",
+          "disabledHint": "当前没有可用提醒次数，订阅后可下发 1 次。"
         },
         "BOOKING_RESULT": {
           "title": "场地预订结果",
-          "enabledHint": "已开启场地预订结果通知。",
-          "disabledHint": "场地预订结果通知已关闭。"
+          "enabledHint": "你可继续接收场地预订结果通知。",
+          "disabledHint": "当前没有可用通知次数，订阅后可下发 1 次。"
         },
         "NEW_PARTNER": {
           "title": "新搭子",
-          "enabledHint": "已开启新搭子通知，有人加入当前活动会提醒你。",
-          "disabledHint": "新搭子通知已关闭。",
+          "enabledHint": "你可继续接收新搭子通知（有人加入当前活动会提醒你）。",
+          "disabledHint": "当前没有可用通知次数，订阅后可下发 1 次。",
           "unconfiguredHint": "当前环境未配置“新搭子”通知模板。"
         }
       }

--- a/apps/frontend/src/pages/MePage.vue
+++ b/apps/frontend/src/pages/MePage.vue
@@ -239,10 +239,12 @@
 
         <WeChatNotificationSubscriptionsCard
           :title="t('mePage.reminder.title')"
-          :items="notificationSubscriptionItems"
-          :updating-label="t('prPage.wechatReminder.updating')"
-          @action="handleNotificationSubscriptionAction"
-        />
+        >
+          <APRNotificationSubscriptions
+            :updating-label="t('prPage.wechatReminder.updating')"
+            @error-change="handleNotificationSubscriptionErrorChange"
+          />
+        </WeChatNotificationSubscriptionsCard>
 
         <section class="surface-card">
           <div class="section-header">
@@ -341,6 +343,7 @@ import ContactSupportFooter from "@/domains/support/ui/sections/ContactSupportFo
 import PageHeader from "@/shared/ui/navigation/PageHeader.vue";
 import PageScaffoldFlow from "@/shared/ui/layout/PageScaffoldFlow.vue";
 import WeChatNotificationSubscriptionsCard from "@/shared/ui/sections/WeChatNotificationSubscriptionsCard.vue";
+import APRNotificationSubscriptions from "@/shared/ui/sections/APRNotificationSubscriptions.vue";
 import { useUserSessionStore } from "@/shared/auth/useUserSessionStore";
 import { useCurrentUserProfile } from "@/domains/user/queries/useCurrentUserProfile";
 import { useUpdateCurrentUserProfile } from "@/domains/user/queries/useUpdateCurrentUserProfile";
@@ -348,7 +351,6 @@ import { useUpdateCurrentUserAvatar } from "@/domains/user/queries/useUpdateCurr
 import { useStartWeChatBind } from "@/domains/user/queries/useStartWeChatBind";
 import { useRegisterLocalAccount } from "@/domains/user/queries/useRegisterLocalAccount";
 import { useLoginWithPin } from "@/domains/user/queries/useLoginWithPin";
-import { useWeChatNotificationSubscriptionsPanel } from "@/shared/wechat/useWeChatNotificationSubscriptionsPanel";
 import { isWeChatBrowser } from "@/shared/browser/isWeChatBrowser";
 import { copyToClipboard } from "@/lib/clipboard";
 import { redirectToWeChatOAuthLogin } from "@/processes/wechat/oauth-login";
@@ -365,19 +367,13 @@ const updateAvatarMutation = useUpdateCurrentUserAvatar();
 const startWeChatBindMutation = useStartWeChatBind();
 const registerLocalAccountMutation = useRegisterLocalAccount();
 const loginWithPinMutation = useLoginWithPin();
-const notificationSubscriptions = useWeChatNotificationSubscriptionsPanel({
-  visibleKinds: [
-    "REMINDER_CONFIRMATION",
-    "BOOKING_RESULT",
-    "NEW_PARTNER",
-  ] as const,
-});
 
 const avatarInputRef = ref<HTMLInputElement | null>(null);
 const nicknameDraft = ref("");
 const pinVisible = ref(false);
 const copiedField = ref<"userId" | "userPin" | null>(null);
 const copyErrorMessage = ref<string | null>(null);
+const notificationSubscriptionsPanelError = ref<Error | null>(null);
 const wechatLoginPending = ref(false);
 const pinLoginDraft = reactive({
   userId: "",
@@ -471,9 +467,6 @@ const bindHintText = computed(() => {
   return t("mePage.wechat.unboundHint");
 });
 
-const notificationSubscriptionItems = computed(
-  () => notificationSubscriptions.items.value,
-);
 const errorMessage = computed(() => {
   const candidates = [
     currentUserQuery.error.value,
@@ -482,7 +475,7 @@ const errorMessage = computed(() => {
     startWeChatBindMutation.error.value,
     registerLocalAccountMutation.error.value,
     loginWithPinMutation.error.value,
-    notificationSubscriptions.mutation.error.value,
+    notificationSubscriptionsPanelError.value,
   ];
 
   const firstError = candidates.find((candidate) => candidate instanceof Error);
@@ -556,10 +549,8 @@ const handleRegisterLocalAccount = async () => {
   userSessionStore.applyAuthSession(payload);
 };
 
-const handleNotificationSubscriptionAction = async (
-  kind: "REMINDER_CONFIRMATION" | "BOOKING_RESULT" | "NEW_PARTNER",
-) => {
-  await notificationSubscriptions.handleAction(kind);
+const handleNotificationSubscriptionErrorChange = (error: Error | null) => {
+  notificationSubscriptionsPanelError.value = error;
 };
 
 const handleCopyCredential = async (

--- a/apps/frontend/src/shared/ui/sections/APRNotificationSubscriptions.vue
+++ b/apps/frontend/src/shared/ui/sections/APRNotificationSubscriptions.vue
@@ -21,18 +21,49 @@
       {{ props.updatingLabel }}
     </button>
 
-    <wx-open-subscribe
+    <div
       v-else-if="
         item.actionKind === 'OPEN_SUBSCRIBE' &&
         item.actionLabel &&
         item.openSubscribeTemplateId &&
         !item.actionDisabled
       "
-      class="open-subscribe"
-      :template="item.openSubscribeTemplateId"
-      @success="handleOpenSubscribeSuccess(item.key, $event)"
-      @error="handleOpenSubscribeError(item.key, $event)"
-    ></wx-open-subscribe>
+      class="open-subscribe-proxy"
+    >
+      <button
+        :class="[
+          'action-btn',
+          props.outlineProfile === 'surface' ? 'action-btn--surface' : 'action-btn--secondary',
+        ]"
+        type="button"
+      >
+        {{ item.actionLabel }}
+      </button>
+
+      <wx-open-subscribe
+        class="open-subscribe-overlay"
+        :template="item.openSubscribeTemplateId"
+        @success="handleOpenSubscribeSuccess(item.key, $event)"
+        @error="handleOpenSubscribeError(item.key, $event)"
+      >
+        <script type="text/wxtag-template" slot="style">
+          <style>
+            .open-subscribe-hit-target {
+              width: 100%;
+              height: 100%;
+              border: 0;
+              margin: 0;
+              padding: 0;
+              background: transparent;
+              cursor: pointer;
+            }
+          </style>
+        </script>
+        <script type="text/wxtag-template">
+          <button class="open-subscribe-hit-target"></button>
+        </script>
+      </wx-open-subscribe>
+    </div>
 
     <button
       v-else-if="item.actionLabel"
@@ -187,14 +218,28 @@ const handleOpenSubscribeError = async (
   color: color-mix(in srgb, var(--sys-color-on-surface) 38%, transparent);
 }
 
-.open-subscribe {
+.open-subscribe-proxy {
+  position: relative;
   display: inline-flex;
+  min-height: 2.5rem;
+}
+
+.open-subscribe-proxy .action-btn {
+  pointer-events: none;
+}
+
+.open-subscribe-overlay {
+  position: absolute;
+  inset: 0;
+  display: inline-flex;
+  width: 100%;
+  height: 100%;
   min-height: 2.5rem;
 }
 
 @media (max-width: 768px) {
   .subscription-card .action-btn,
-  .subscription-card .open-subscribe {
+  .subscription-card .open-subscribe-proxy {
     width: 100%;
   }
 }

--- a/apps/frontend/src/shared/wechat/queries/useUpdateWeChatNotificationSubscription.ts
+++ b/apps/frontend/src/shared/wechat/queries/useUpdateWeChatNotificationSubscription.ts
@@ -13,9 +13,11 @@ type WeChatNotificationKind =
   | "BOOKING_RESULT"
   | "NEW_PARTNER";
 
+type WeChatNotificationAction = "ADD_ONE" | "CLEAR";
+
 type UpdateWeChatNotificationSubscriptionInput = {
   kind: WeChatNotificationKind;
-  enabled: boolean;
+  action: WeChatNotificationAction;
 };
 
 export const useUpdateWeChatNotificationSubscription = () => {
@@ -24,11 +26,11 @@ export const useUpdateWeChatNotificationSubscription = () => {
   return useMutation({
     mutationFn: async ({
       kind,
-      enabled,
+      action,
     }: UpdateWeChatNotificationSubscriptionInput) => {
       const res = await client.api.wechat.notifications.subscriptions.$post(
         {
-          json: { kind, enabled },
+          json: { kind, action },
         },
         {
           init: {

--- a/apps/frontend/src/shared/wechat/useWeChatNotificationSubscriptionsPanel.ts
+++ b/apps/frontend/src/shared/wechat/useWeChatNotificationSubscriptionsPanel.ts
@@ -18,7 +18,7 @@ export type WeChatNotificationKind =
   | "NEW_PARTNER";
 
 type NotificationActionKind =
-  | "TOGGLE"
+  | "ADD_ONE"
   | "OPEN_SUBSCRIBE"
   | "LOGIN"
   | "BIND"
@@ -120,7 +120,6 @@ export const useWeChatNotificationSubscriptionsPanel = ({
       const entry = payload.subscriptions[kind];
       return Boolean(
         entry &&
-          !entry.enabled &&
           entry.configured &&
           entry.requiresOpenSubscribe &&
           entry.templateId,
@@ -210,11 +209,12 @@ export const useWeChatNotificationSubscriptionsPanel = ({
       return;
     }
 
-    const enabled = query.data.value?.subscriptions[kind].enabled ?? false;
-    await mutation.mutateAsync({
-      kind,
-      enabled: !enabled,
-    });
+    if (item.actionKind === "ADD_ONE") {
+      await mutation.mutateAsync({
+        kind,
+        action: "ADD_ONE",
+      });
+    }
   };
 
   const handleOpenSubscribeSuccess = async (
@@ -231,10 +231,20 @@ export const useWeChatNotificationSubscriptionsPanel = ({
       ? parseOpenSubscribeStatus(detail, templateId)
       : "unknown";
 
-    await mutation.mutateAsync({
-      kind,
-      enabled: status === "accept",
-    });
+    if (status === "accept") {
+      await mutation.mutateAsync({
+        kind,
+        action: "ADD_ONE",
+      });
+      return;
+    }
+
+    if (status === "reject") {
+      await mutation.mutateAsync({
+        kind,
+        action: "CLEAR",
+      });
+    }
   };
 
   const handleOpenSubscribeError = async (
@@ -249,11 +259,6 @@ export const useWeChatNotificationSubscriptionsPanel = ({
         openSubscribeError.value = [errCode, errMsg].filter(Boolean).join(": ");
       }
     }
-
-    await mutation.mutateAsync({
-      kind,
-      enabled: false,
-    });
   };
 
   const resolveItemTitle = (kind: WeChatNotificationKind): string => {
@@ -306,7 +311,8 @@ export const useWeChatNotificationSubscriptionsPanel = ({
 
     for (const kind of visibleKinds) {
       const entry = payload?.subscriptions[kind];
-      const enabled = entry?.enabled ?? false;
+      const remainingCount = Math.max(0, entry?.remainingCount ?? 0);
+      const enabled = remainingCount > 0;
       const kindConfigured = entry?.configured ?? false;
       const pending = mutation.isPending.value && pendingKind === kind;
 
@@ -345,15 +351,19 @@ export const useWeChatNotificationSubscriptionsPanel = ({
         actionKind = "BIND";
         actionDisabled = false;
       } else {
-        description = enabled
+        const itemHint = enabled
           ? resolveItemEnabledHint(kind)
           : resolveItemDisabledHint(kind);
-        actionLabel = enabled
-          ? t("prPage.wechatReminder.disableAction")
-          : t("prPage.wechatReminder.enableAction");
+        description = t(
+          "prPage.notificationSubscriptions.remainingCountWithHint",
+          {
+            count: remainingCount,
+            hint: itemHint,
+          },
+        );
+        actionLabel = t("prPage.notificationSubscriptions.subscribeOnceAction");
 
         if (
-          !enabled &&
           requiresOpenSubscribe &&
           !isWeChatAbilityMockingEnabled()
         ) {
@@ -370,7 +380,7 @@ export const useWeChatNotificationSubscriptionsPanel = ({
             );
           }
         } else {
-          actionKind = "TOGGLE";
+          actionKind = "ADD_ONE";
           actionDisabled = pending;
         }
       }

--- a/docs/product/features/find-partner.md
+++ b/docs/product/features/find-partner.md
@@ -28,7 +28,7 @@
 - 发布 `DRAFT` 时，系统会为创建者绑定用户身份并生成/确保用户 PIN（4 位数字）；`user-id` 与 `user-pin` 缓存在前端 localStorage。
 - 会话初始化：进入网页时自动调用 `/api/auth/session`。若已有本地 `user-id/user-pin`，则静默登录；若无凭据则保持匿名，第一次发布搭子请求时自动创建本地账户并登录。
 - 创建成功时系统会按 `min/max` 预创建 `partners` 槽位；对已发布请求会保证“创建者占用一个槽位”。
-- `/me` 作为个人中心：展示当前资料、微信绑定、公众号服务通知开关、本地 `user-id/user-pin`，并提供进入历史列表的入口。
+- `/me` 作为个人中心：展示当前资料、微信绑定、公众号服务通知次数、本地 `user-id/user-pin`，并提供进入历史列表的入口。
 - `/pr/mine` 聚合展示“我创建的 / 我加入的”列表，列表项按 canonicalPath 跳转到 `/cpr/:id` 或 `/apr/:id`。
 - 页面头部返回按钮默认遵循“有历史则返回、无历史则回退”的规则：
   - 默认回退到首页 `/`；
@@ -61,20 +61,21 @@
 - Anchor PR 详情页提供可选签到反馈（仅“我已到场”），调用 `POST /api/apr/:id/check-in`；提交后槽位进入 `ATTENDED`，并记录 `wouldJoinAgain`。未提交签到视为 `CHECKIN_UNKNOWN`（`didAttend=null`）。
 - `/me` 与 Anchor PR 详情页共用“通知订阅”卡片，查询/更新接口为：
   - `GET /api/wechat/notifications/subscriptions`
-  - `POST /api/wechat/notifications/subscriptions`（`kind: "REMINDER_CONFIRMATION" | "BOOKING_RESULT" | "NEW_PARTNER"`, `enabled: boolean`）
-- 对于 `REMINDER_CONFIRMATION` 与 `NEW_PARTNER`：
+  - `POST /api/wechat/notifications/subscriptions`（`kind: "REMINDER_CONFIRMATION" | "BOOKING_RESULT" | "NEW_PARTNER"`, `action: "ADD_ONE" | "CLEAR"`）
+- 三个通知项都采用“剩余可发送次数（`remainingCount`）”模型：
   - 前端在微信环境使用 `wx-open-subscribe` 触发订阅授权；
-  - 授权结果直接映射开关状态：`accept => enabled=true`，`reject/cancel/filter/error => enabled=false`。
+  - 授权结果映射：`accept => action=ADD_ONE`，`reject => action=CLEAR`，`cancel/filter/error => 不变更次数`。
 - 兼容接口仍保留：
   - `GET /api/wechat/reminders/subscription`
   - `POST /api/wechat/reminders/subscription`（映射到 `REMINDER_CONFIRMATION`）
-- `REMINDER_CONFIRMATION` 开启后，系统会为已加入的 Anchor PR 槽位调度 `T-24h` 与 `T-2h` 提醒任务。
+- `REMINDER_CONFIRMATION` 有剩余次数时，系统会为已加入的 Anchor PR 槽位调度 `T-24h` 与 `T-2h` 提醒任务。
 - `REMINDER_CONFIRMATION` 订阅通知模板 ID 通过后端配置表 key `wechat.submsg_confirmation_reminder_template_id` 读取。
-- Anchor PR 退出、自动释放或关闭 `REMINDER_CONFIRMATION` 时，系统会删除对应未执行提醒任务（`PENDING/RETRY`）。
-- `NEW_PARTNER` 开启后，系统会在 Anchor PR 有新参与者加入时，向同 PR 其他活跃参与者发送订阅通知。
+- `BOOKING_RESULT` 订阅通知模板 ID 通过后端配置表 key `wechat.submsg_booking_result_template_id` 读取。
+- Anchor PR 退出、自动释放或 `REMINDER_CONFIRMATION` 次数归零时，系统会删除对应未执行提醒任务（`PENDING/RETRY`）。
+- `NEW_PARTNER` 有剩余次数时，系统会在 Anchor PR 有新参与者加入时，向同 PR 其他活跃参与者发送订阅通知。
 - `NEW_PARTNER` 模板 ID 通过后端配置表 key `wechat.submsg_new_partner_template_id` 读取。
-- 若发送链路返回 `43101`（用户拒收订阅消息），系统会自动将对应通知项关闭，并清理该用户该通知项的待执行任务。
-- `BOOKING_RESULT` 当前仅支持开关持久化，不触发发送链路。
+- 若发送链路返回 `43101`（用户拒收订阅消息），系统会自动将对应通知项次数清零，并清理该用户该通知项的待执行任务。
+- `BOOKING_RESULT` 当前仅支持次数持久化，不触发发送链路。
 - 编辑内容弹窗复用同一结构化表单组件并提交更新；`READY` 及之后状态禁止任何 user-facing 内容编辑。
 - 当 `OPEN` 状态 PR 修改时间窗口时，系统会对当前所有活跃参与者执行同一时间冲突校验；若任一参与者发生冲突则拒绝本次修改（`409`，`JOIN_TIME_WINDOW_CONFLICT`）。
 - 创建者编辑规则：JWT `authenticated/service` 角色可直接编辑；JWT `anonymous` 角色需输入用户 PIN，验证成功后会升级 token。
@@ -112,12 +113,12 @@
 - `POST /api/apr/:id/join`、`POST /api/apr/:id/exit`、`POST /api/apr/:id/confirm`、`POST /api/apr/:id/check-in` 在无有效微信会话时返回 401（或 OAuth 未配置时返回 503）。
 - `GET /api/cpr/:id/partners/:partnerId/profile` 与 `GET /api/apr/:id/partners/:partnerId/profile` 仅在目标 slot 属于当前 PR 且为活跃参与状态时返回资料；否则返回 404。
 - `POST /api/wechat/reminders/subscription` 在无有效微信会话时返回 401（或 OAuth 未配置时返回 503）。
-- 开启提醒后会创建具备 dedupe 的延迟任务；关闭提醒后会删除对应未执行任务并返回删除数量。
+- `REMINDER_CONFIRMATION` 次数从 0 变为正数时会创建具备 dedupe 的延迟任务；次数归零后会删除对应未执行任务并返回删除数量。
 - 提醒任务执行后会写入 `notification_deliveries`（包含 `result/errorCode/jobId`）。
-- `GET /api/wechat/notifications/subscriptions` 会按通知项返回 `enabled/optInAt/configured/requiresOpenSubscribe/templateId`。
+- `GET /api/wechat/notifications/subscriptions` 会按通知项返回 `enabled/optInAt/remainingCount/configured/requiresOpenSubscribe/templateId`。
 - `POST /api/wechat/notifications/subscriptions` 在无有效微信会话时返回 401（或 OAuth 未配置时返回 503）。
-- `POST /api/wechat/notifications/subscriptions` 的 `kind=NEW_PARTNER` 关闭时会清理未执行的新搭子通知任务。
-- `POST /api/wechat/notifications/subscriptions` 在 `REMINDER_CONFIRMATION` / `NEW_PARTNER` 的启用动作中，前端会先走微信开放标签订阅，最终以开放标签返回结果持久化启停状态。
+- `POST /api/wechat/notifications/subscriptions` 的 `kind=NEW_PARTNER` 在次数清零时会清理未执行的新搭子通知任务。
+- `POST /api/wechat/notifications/subscriptions` 在微信开放标签场景下：`accept` 增加次数，`reject` 清零次数，`cancel/filter/error` 不变更次数。
 - 仅 Anchor PR 在 `T-30min` 之后拒绝 join 请求（400）。
 - 仅 Anchor PR 在到达 `T-1h` 且槽位未确认时，会在读取/操作时懒触发自动释放，保证结构状态收敛。
 - Anchor PR 详情页签到仅展示“我已到场”；不再提供“我未到场”提交动作。

--- a/docs/product/glossary.md
+++ b/docs/product/glossary.md
@@ -23,7 +23,7 @@
 - Check-in Signal：Anchor PR 专属签到回流信号（attended only：`didAttend=true` + `wouldJoinAgain`）；未提交时保持 `didAttend=null`，记为 `CHECKIN_UNKNOWN`。
 - User（最小模型）：核心用户主体，`users.id` 使用 UUID；表内维护身份、角色与资料字段（`openid`、`role=anonymous/authenticated/service`、`nickname`、`sex`、`avatar`、`pin_hash`、`status`）。
 - UserReliability：用户可靠性统计表（`user_reliability`），维护 join / confirm / attend / release 计数与派生比率。
-- UserNotificationOpts：用户通知偏好表（`user_notification_opts`），当前维护 3 个公众号通知开关：`REMINDER_CONFIRMATION`（活动前提醒）、`BOOKING_RESULT`（场地预订结果）、`NEW_PARTNER`（新搭子）。
+- UserNotificationOpts：用户通知偏好表（`user_notification_opts`），当前维护 3 个公众号通知项的剩余次数（`remainingCount`）：`REMINDER_CONFIRMATION`（活动前提醒）、`BOOKING_RESULT`（场地预订结果）、`NEW_PARTNER`（新搭子）。
 - 分享链接：指向 `/cpr/:id` 或 `/apr/:id` 页面、可复制传播的链接。
 - 小红书文案：用于发布到小红书的分享文本。
 - 分享海报：用于社交平台传播的图片。

--- a/docs/product/overview.md
+++ b/docs/product/overview.md
@@ -42,9 +42,10 @@ PartnerUp MVP-HA 是一个协作效率产品（H-A）：把“群里的一句话
 - 在 Community / Anchor PR 的参与名单中，每条 roster item 展示头像 + 昵称；点击后可进入该参与者资料页（只读）。
 - Community PR 详情页仅提供 `join/exit`。
 - Anchor PR 详情页提供 `join/exit`、确认参与与可选签到（仅“到场”）反馈；未提交签到默认为 `CHECKIN_UNKNOWN`，用于可靠性与信任回流。
-- Anchor PR 与 `/me` 页面共用“通知订阅”卡片，当前包含 3 个全局开关：`REMINDER_CONFIRMATION`（公众号提醒）、`BOOKING_RESULT`（场地预订结果）、`NEW_PARTNER`（新搭子）。
-- `REMINDER_CONFIRMATION` 与 `NEW_PARTNER` 在微信环境中采用服务号开放标签订阅（`wx-open-subscribe`）作为开关真值来源：用户授权成功视为开启，拒绝/取消/过滤/失败视为关闭。
-- `REMINDER_CONFIRMATION` 开启后会按 `T-24h` 与 `T-2h` 触发服务号订阅通知提醒（模板消息通道保留为兼容兜底），关闭后会清理未执行提醒任务。
-- `NEW_PARTNER` 开启后，当你已加入的 Anchor PR 有新参与者加入时会触发服务号订阅通知。
-- 发送链路若返回 `43101`（用户拒收订阅消息），后端会自动关闭对应通知开关并清理该用户待执行通知任务，避免重复失败。
-- `BOOKING_RESULT` 当前仅支持开关持久化，发送链路待后续预订处理控制台接入。
+- Anchor PR 与 `/me` 页面共用“通知订阅”卡片，当前包含 3 个全局通知项：`REMINDER_CONFIRMATION`（公众号提醒）、`BOOKING_RESULT`（场地预订结果）、`NEW_PARTNER`（新搭子）。
+- 通知订阅按“剩余可发送次数（remainingCount）”建模，而不是简单开关：每次成功订阅会增加 1 次发送额度。
+- 三个通知项在微信环境都可通过服务号开放标签（`wx-open-subscribe`）订阅；其中 `accept` 会增加 1 次，`reject` 会清零该通知项次数，`cancel/filter/error` 保持原次数不变。
+- `REMINDER_CONFIRMATION` 有剩余次数时会按 `T-24h` 与 `T-2h` 触发服务号订阅通知提醒（模板消息通道保留为兼容兜底）；次数归零后会清理未执行提醒任务。
+- `NEW_PARTNER` 有剩余次数时，当你已加入的 Anchor PR 有新参与者加入会触发服务号订阅通知；次数归零后会清理该用户待执行的新搭子通知任务。
+- 发送链路若返回 `43101`（用户拒收订阅消息），后端会自动将对应通知项次数清零并清理待执行任务，避免重复失败。
+- `BOOKING_RESULT` 当前仅做次数持久化与订阅链路配置，发送链路待后续预订处理控制台接入。


### PR DESCRIPTION
## Summary
- switch WeChat notification subscriptions from boolean on/off to credit-based quota (`remainingCount`)
- add operation-based API for `/api/wechat/notifications/subscriptions` (`ADD_ONE` / `CLEAR`)
- map `wx-open-subscribe` results to quota updates (`accept => +1`, `reject => clear`, `cancel/filter/error => unchanged`)
- consume one credit per successful reminder/new-partner delivery; `43101` clears credits and cancels pending jobs
- fix `MePage` to use the extracted `APRNotificationSubscriptions` composition pattern
- customize `wx-open-subscribe` button rendering to match our action-button visual style

## Backend
- add migration `0009_user_notification_opt_remaining_counts.sql`
- add per-kind remaining count columns in `user_notification_opts`
- add booking-result template config support via `wechat.submsg_booking_result_template_id`

## Frontend
- switch mutation payload to action-based contract
- update panel copy/UX to show remaining count and subscribe-one-more behavior

## Docs
- update product docs to reflect quota model, action contract, and `43101` handling

## Validation
- `pnpm --filter @partner-up-dev/backend typecheck`
- `pnpm --filter @partner-up-dev/backend build`
- `pnpm --filter @partner-up-dev/frontend build`

Related: #36 (comment 4124468217)