### PR TITLE
fix: schedule confirmation reminders by confirm window

### DIFF
--- a/apps/backend/AGENTS.md
+++ b/apps/backend/AGENTS.md
@@ -95,7 +95,7 @@ src/
 - 参与数据模型: 已迁移为 `minPartners` / `maxPartners` + `partners: partnerId[]`，并新增 `Partner`（含 `status`: `JOINED/CONFIRMED/RELEASED/ATTENDED`）用于 slot 级参与者标识。
 - 用户最小模型: 新增 `users` 表（`openid` 唯一绑定，含 `nickname/sex/avatar` + `ACTIVE/DISABLED`）；Community PR 加入可复用本地用户 / PIN 账户并在首次加入时自动创建本地用户，Anchor PR join/exit/confirm/check-in 依赖 JWT authenticated 会话 + `users.openid` 绑定关系。
 - 确认机制（5.2）: 新增 `/api/pr/:id/confirm`；`T-1h` 自动释放未确认 `JOINED` 槽位，`T-1h~T-30min` 加入即自动确认，`T-30min` 后禁止 join。
-- 公众号提醒（5.2）: 新增 `GET/POST /api/wechat/reminders/subscription`；当前仅 Anchor PR 参与会调度 `T-24h/T-2h` 任务（优先服务号订阅通知 `message/subscribe/bizsend`，模板 ID 读取 `config` 表 key `wechat.submsg_confirmation_reminder_template_id`；模板消息通道保留兜底），退出/释放/关闭提醒会删除待执行任务，发送结果落库 `notification_deliveries`。
+- 公众号提醒（5.2）: 新增 `GET/POST /api/wechat/reminders/subscription`；当前仅 Anchor PR 参与会调度 `confirm_start` 与 `confirm_end - 30min` 任务（优先服务号订阅通知 `message/subscribe/bizsend`，模板 ID 读取 `config` 表 key `wechat.submsg_confirmation_reminder_template_id`；模板消息通道保留兜底），退出/释放/关闭提醒会删除待执行任务，发送结果落库 `notification_deliveries`。
 - 签到回流（5.3）: 新增 `/api/pr/:id/check-in`，记录 `didAttend` / `wouldJoinAgain`，到场时槽位置为 `ATTENDED`。
 - 分享能力: 提供小红书文案/海报与微信缩略图生成能力，并支持缓存到后端。
 - 公共配置能力: 提供 `/api/config/public/:key` 只读配置查询（当前支持 `author_wechat_qr_code`、`wecom_staff_link`、`wecom_service_qr_code`、`wecom_support_link_wechat_in`、`wecom_support_link_wechat_out`、`wechat_official_account_username`）。

--- a/apps/backend/src/infra/notifications/wechat-reminder.ts
+++ b/apps/backend/src/infra/notifications/wechat-reminder.ts
@@ -8,10 +8,12 @@ import {
 import { userIdSchema, type UserId } from "../../entities/user";
 import { PartnerRepository } from "../../repositories/PartnerRepository";
 import { PartnerRequestRepository } from "../../repositories/PartnerRequestRepository";
+import { AnchorPRRepository } from "../../repositories/AnchorPRRepository";
 import { UserRepository } from "../../repositories/UserRepository";
 import { UserNotificationOptRepository } from "../../repositories/UserNotificationOptRepository";
 import { NotificationDeliveryRepository } from "../../repositories/NotificationDeliveryRepository";
 import { getTimeWindowStart } from "../../domains/pr-core/services/time-window.service";
+import { resolveAnchorParticipationPolicy } from "../../domains/pr-core/services/anchor-participation-policy.service";
 import { jobRunner, NO_LATE_TOLERANCE_MS, type JobHandlerContext } from "../jobs";
 import {
   WeChatTemplateMessageError,
@@ -26,6 +28,7 @@ import { env } from "../../lib/env";
 const WECHAT_REMINDER_JOB_TYPE = "wechat.reminder.confirmation";
 const REMINDER_DEDUPE_PREFIX = "wechat-reminder";
 const REMINDER_TYPES: readonly ReminderType[] = ["T_MINUS_24H", "T_MINUS_2H"];
+const CONFIRMATION_END_REMINDER_LEAD_MS = 30 * 60 * 1000;
 const WECHAT_NEW_PARTNER_JOB_TYPE = "wechat.notification.new-partner";
 const NEW_PARTNER_DEDUPE_PREFIX = "wechat-new-partner";
 const NEW_PARTNER_TIP = "有新搭子加入请及时确认";
@@ -51,6 +54,7 @@ type NewPartnerPayload = z.infer<typeof newPartnerPayloadSchema>;
 
 const prRepo = new PartnerRequestRepository();
 const partnerRepo = new PartnerRepository();
+const anchorPRRepo = new AnchorPRRepository();
 const userRepo = new UserRepository();
 const userNotificationOptRepo = new UserNotificationOptRepository();
 const deliveryRepo = new NotificationDeliveryRepository();
@@ -59,11 +63,6 @@ const templateService = new WeChatTemplateMessageService();
 
 let reminderHandlerRegistered = false;
 let newPartnerHandlerRegistered = false;
-
-const reminderOffsetMsByType: Record<ReminderType, number> = {
-  T_MINUS_24H: 24 * 60 * 60 * 1000,
-  T_MINUS_2H: 2 * 60 * 60 * 1000,
-};
 
 const buildReminderDedupeKey = (
   prId: PRId,
@@ -85,12 +84,22 @@ const buildNewPartnerDedupePrefixForUser = (userId: UserId): string =>
   `${NEW_PARTNER_DEDUPE_PREFIX}:${userId}:`;
 
 const getReminderRunAt = (
-  request: PartnerRequest,
+  policy: Pick<
+    ReturnType<typeof resolveAnchorParticipationPolicy>,
+    "confirmationStartAt" | "confirmationEndAt"
+  >,
   reminderType: ReminderType,
 ): Date | null => {
-  const start = getTimeWindowStart(request.time);
-  if (!start) return null;
-  return new Date(start.getTime() - reminderOffsetMsByType[reminderType]);
+  if (reminderType === "T_MINUS_24H") {
+    return policy.confirmationStartAt;
+  }
+
+  if (!policy.confirmationEndAt) {
+    return null;
+  }
+  return new Date(
+    policy.confirmationEndAt.getTime() - CONFIRMATION_END_REMINDER_LEAD_MS,
+  );
 };
 
 const resolvePrUrl = (request: PartnerRequest): string | null => {
@@ -185,7 +194,9 @@ const resolveReminderOrderNo = (
 ): string => `PR-${request.id}-${userId.slice(-6)}`;
 
 const resolveReminderRemark = (reminderType: ReminderType): string =>
-  reminderType === "T_MINUS_24H" ? "活动前24小时提醒" : "活动前2小时提醒";
+  reminderType === "T_MINUS_24H"
+    ? "确认开启提醒"
+    : "确认截止前30分钟提醒";
 
 const resolveTeamName = (request: PartnerRequest): string =>
   request.title?.trim() || request.type || `PR#${request.id}`;
@@ -396,6 +407,17 @@ export async function scheduleWeChatReminderJobsForParticipant(
   request: PartnerRequest,
   userId: UserId,
 ): Promise<void> {
+  if (request.prKind !== "ANCHOR") {
+    return;
+  }
+
+  const anchor = await anchorPRRepo.findByPrId(request.id);
+  if (!anchor) {
+    return;
+  }
+
+  const policy = resolveAnchorParticipationPolicy(anchor, request.time);
+
   const user = await userRepo.findById(userId);
   const notificationOpt = user
     ? await userNotificationOptRepo.findByUserId(userId)
@@ -409,7 +431,7 @@ export async function scheduleWeChatReminderJobsForParticipant(
   }
 
   for (const reminderType of REMINDER_TYPES) {
-    const runAt = getReminderRunAt(request, reminderType);
+    const runAt = getReminderRunAt(policy, reminderType);
     if (!runAt || runAt.getTime() <= Date.now()) {
       continue;
     }

--- a/apps/backend/src/services/WeChatTemplateMessageService.ts
+++ b/apps/backend/src/services/WeChatTemplateMessageService.ts
@@ -121,7 +121,9 @@ export class WeChatTemplateMessageService {
     url.searchParams.set("access_token", accessToken);
 
     const reminderLabel =
-      params.reminderType === "T_MINUS_24H" ? "活动前 24 小时提醒" : "活动前 2 小时提醒";
+      params.reminderType === "T_MINUS_24H"
+        ? "确认开启提醒"
+        : "确认截止前 30 分钟提醒";
 
     const response = await proxyFetch(url, {
       method: "POST",
@@ -157,4 +159,3 @@ export class WeChatTemplateMessageService {
     return payload.msgid ?? null;
   }
 }
-

--- a/apps/frontend/src/locales/zh-CN.jsonc
+++ b/apps/frontend/src/locales/zh-CN.jsonc
@@ -335,7 +335,7 @@
       "nonWechatHint": "当前不在微信环境，无法开启公众号提醒。",
       "unconfiguredHint": "当前环境未配置公众号提醒通道。",
       "loginHint": "需要先完成微信登录后才能开启提醒。",
-      "enabledHint": "已开启提醒：活动前 24 小时和 2 小时会发送通知。",
+      "enabledHint": "已开启提醒：确认开始和确认截止前 30 分钟会发送通知。",
       "disabledHint": "提醒已关闭，可随时开启。"
     },
     "notificationSubscriptions": {
@@ -346,7 +346,7 @@
       "items": {
         "REMINDER_CONFIRMATION": {
           "title": "确认席位提醒",
-          "enabledHint": "你可继续接收确认席位提醒（活动前 24 小时和 2 小时）。",
+          "enabledHint": "你可继续接收确认席位提醒（确认开始和确认截止前 30 分钟）。",
           "disabledHint": "当前没有可用提醒次数，订阅后可下发 1 次。"
         },
         "BOOKING_RESULT": {

--- a/apps/frontend/src/shared/wechat/useWeChatOfficialAccountFollow.ts
+++ b/apps/frontend/src/shared/wechat/useWeChatOfficialAccountFollow.ts
@@ -7,7 +7,7 @@ import {
 import { isWeChatAbilityEnv } from "@/shared/wechat/ability-mocking";
 import { useWeChatShare } from "@/shared/wechat/useWeChatShare";
 
-const FALLBACK_OFFICIAL_ACCOUNT_USERNAME = "PartnerUp_Official";
+const FALLBACK_OFFICIAL_ACCOUNT_USERNAME = "Partner_Up_Official";
 
 const normalizeOfficialAccountUsername = (
   value: string | null | undefined,
@@ -19,7 +19,9 @@ export const useWeChatOfficialAccountFollow = () => {
     PUBLIC_CONFIG_KEYS.wechatOfficialAccountUsername,
   );
   const configuredOfficialAccountUsername = computed(() =>
-    normalizeOfficialAccountUsername(officialAccountConfigQuery.data.value?.value),
+    normalizeOfficialAccountUsername(
+      officialAccountConfigQuery.data.value?.value,
+    ),
   );
   const officialAccountUsername = computed(
     () =>
@@ -91,8 +93,6 @@ export const useWeChatOfficialAccountFollow = () => {
     followSchemeUrl,
     isConfigured: computed(() => officialAccountUsername.value.length > 0),
     officialAccountUsername,
-    configLoading: computed(
-      () => officialAccountConfigQuery.isLoading.value,
-    ),
+    configLoading: computed(() => officialAccountConfigQuery.isLoading.value),
   };
 };

--- a/docs/product/features/find-partner.md
+++ b/docs/product/features/find-partner.md
@@ -68,7 +68,7 @@
 - 兼容接口仍保留：
   - `GET /api/wechat/reminders/subscription`
   - `POST /api/wechat/reminders/subscription`（映射到 `REMINDER_CONFIRMATION`）
-- `REMINDER_CONFIRMATION` 有剩余次数时，系统会为已加入的 Anchor PR 槽位调度 `T-24h` 与 `T-2h` 提醒任务。
+- `REMINDER_CONFIRMATION` 有剩余次数时，系统会为已加入的 Anchor PR 槽位调度 `confirm_start` 与 `confirm_end - 30min` 提醒任务。
 - `REMINDER_CONFIRMATION` 订阅通知模板 ID 通过后端配置表 key `wechat.submsg_confirmation_reminder_template_id` 读取。
 - `BOOKING_RESULT` 订阅通知模板 ID 通过后端配置表 key `wechat.submsg_booking_result_template_id` 读取。
 - Anchor PR 退出、自动释放或 `REMINDER_CONFIRMATION` 次数归零时，系统会删除对应未执行提醒任务（`PENDING/RETRY`）。

--- a/docs/product/overview.md
+++ b/docs/product/overview.md
@@ -45,7 +45,7 @@ PartnerUp MVP-HA 是一个协作效率产品（H-A）：把“群里的一句话
 - Anchor PR 与 `/me` 页面共用“通知订阅”卡片，当前包含 3 个全局通知项：`REMINDER_CONFIRMATION`（公众号提醒）、`BOOKING_RESULT`（场地预订结果）、`NEW_PARTNER`（新搭子）。
 - 通知订阅按“剩余可发送次数（remainingCount）”建模，而不是简单开关：每次成功订阅会增加 1 次发送额度。
 - 三个通知项在微信环境都可通过服务号开放标签（`wx-open-subscribe`）订阅；其中 `accept` 会增加 1 次，`reject` 会清零该通知项次数，`cancel/filter/error` 保持原次数不变。
-- `REMINDER_CONFIRMATION` 有剩余次数时会按 `T-24h` 与 `T-2h` 触发服务号订阅通知提醒（模板消息通道保留为兼容兜底）；次数归零后会清理未执行提醒任务。
+- `REMINDER_CONFIRMATION` 有剩余次数时会按 `confirm_start` 与 `confirm_end - 30min` 触发服务号订阅通知提醒（模板消息通道保留为兼容兜底）；次数归零后会清理未执行提醒任务。
 - `NEW_PARTNER` 有剩余次数时，当你已加入的 Anchor PR 有新参与者加入会触发服务号订阅通知；次数归零后会清理该用户待执行的新搭子通知任务。
 - 发送链路若返回 `43101`（用户拒收订阅消息），后端会自动将对应通知项次数清零并清理待执行任务，避免重复失败。
 - `BOOKING_RESULT` 当前仅做次数持久化与订阅链路配置，发送链路待后续预订处理控制台接入。


### PR DESCRIPTION
## Summary
- change reminder job scheduling to follow Anchor confirmation policy instead of fixed T-24h/T-2h
- schedule confirmation reminders at confirm_start and confirm_end - 30min
- update reminder copy and docs to match the new timing semantics
- include existing frontend follow-flow adjustment in useWeChatOfficialAccountFollow.ts

## Validation
- pnpm build

Fixes #55