### PR TITLE
Fix Anchor Event card swipe fly-out animation

### DIFF
--- a/apps/frontend/src/domains/event/ui/primitives/AnchorEventDemandCard.vue
+++ b/apps/frontend/src/domains/event/ui/primitives/AnchorEventDemandCard.vue
@@ -3,13 +3,14 @@
     class="demand-card"
     :class="{
       'demand-card--dragging': isDragging,
-      'demand-card--pending': pending,
+      'demand-card--pending': isPendingState,
     }"
     :style="cardStyle"
     @pointerdown="handlePointerDown"
     @pointermove="handlePointerMove"
     @pointerup="handlePointerUp"
     @pointercancel="handlePointerCancel"
+    @transitionend="handleTransitionEnd"
   >
     <div class="demand-card__stamps" aria-hidden="true">
       <span
@@ -65,7 +66,7 @@
         <button
           type="button"
           class="demand-card__action demand-card__action--skip"
-          :disabled="pending"
+          :disabled="isInteractionLocked"
           @pointerdown.stop
           @click="emit('skip')"
         >
@@ -74,7 +75,7 @@
         <button
           type="button"
           class="demand-card__action demand-card__action--detail"
-          :disabled="pending || detailPrId === null"
+          :disabled="isInteractionLocked || detailPrId === null"
           @pointerdown.stop
           @click="emit('view-detail')"
         >
@@ -86,7 +87,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onBeforeUnmount, ref } from "vue";
+import { computed, ref, watch } from "vue";
 import { useI18n } from "vue-i18n";
 
 const MAX_DRAG_DISTANCE = 260;
@@ -100,7 +101,6 @@ const REBOUND_TRANSITION = "transform 440ms cubic-bezier(0.22, 1.35, 0.36, 1)";
 const MILLISECONDS_PER_SECOND = 1000;
 const EXIT_VIEWPORT_MULTIPLIER = 1.1;
 const EXIT_DRAG_MULTIPLIER = 1.5;
-const ACTION_EMIT_DELAY_MS = 180;
 
 type PointerState = {
   pointerId: number;
@@ -110,6 +110,9 @@ type PointerState = {
   tiltDirectionFactor: number;
   pivotY: number;
 };
+
+type SwipeAction = "skip" | "view-detail";
+type SwipePhase = "idle" | "dragging" | "exiting" | "rebounding";
 
 const props = withDefaults(
   defineProps<{
@@ -139,9 +142,20 @@ const translateX = ref(0);
 const rawTranslateX = ref(0);
 const swipeThreshold = ref(MIN_DISTANCE_THRESHOLD);
 const settleTransition = ref(REBOUND_TRANSITION);
-const actionTimeoutId = ref<number | null>(null);
+const swipePhase = ref<SwipePhase>("idle");
+const pendingAction = ref<SwipeAction | null>(null);
+const hasDispatchedExitAction = ref(false);
 
-const isDragging = computed(() => activePointer.value !== null);
+const isDragging = computed(() => swipePhase.value === "dragging");
+const isPendingState = computed(
+  () => props.pending || swipePhase.value === "exiting",
+);
+const isInteractionLocked = computed(
+  () =>
+    props.pending ||
+    swipePhase.value === "exiting" ||
+    swipePhase.value === "rebounding",
+);
 const dragProgress = computed(() =>
   Math.min(Math.abs(rawTranslateX.value) / swipeThreshold.value, 1),
 );
@@ -169,7 +183,7 @@ const cardStyle = computed(() => {
   return {
     transformOrigin: transformOrigin.value,
     transform: `translateX(${translateX.value}px) rotate(${rotationDeg.value}deg) scale(${scale})`,
-    transition: isDragging.value ? "none" : settleTransition.value,
+    transition: swipePhase.value === "dragging" ? "none" : settleTransition.value,
   };
 });
 
@@ -180,28 +194,48 @@ const applyDamping = (offsetX: number): number => {
   return sign * damped;
 };
 
-const resetDrag = () => {
+const resetCardState = () => {
   activePointer.value = null;
   translateX.value = 0;
   rawTranslateX.value = 0;
   settleTransition.value = REBOUND_TRANSITION;
+  swipePhase.value = "idle";
+  pendingAction.value = null;
+  hasDispatchedExitAction.value = false;
 };
 
-const clearActionTimeout = () => {
-  if (actionTimeoutId.value === null) {
-    return;
-  }
-  window.clearTimeout(actionTimeoutId.value);
-  actionTimeoutId.value = null;
+const startRebound = () => {
+  activePointer.value = null;
+  pendingAction.value = null;
+  hasDispatchedExitAction.value = false;
+  swipePhase.value = "rebounding";
+  settleTransition.value = REBOUND_TRANSITION;
+  translateX.value = 0;
+  rawTranslateX.value = 0;
+};
+
+const startExit = (action: SwipeAction) => {
+  const direction = action === "skip" ? -1 : 1;
+
+  activePointer.value = null;
+  pendingAction.value = action;
+  hasDispatchedExitAction.value = false;
+  swipePhase.value = "exiting";
+  settleTransition.value = EXIT_TRANSITION;
+  rawTranslateX.value = direction * swipeThreshold.value;
+  translateX.value =
+    direction *
+    Math.max(
+      window.innerWidth * EXIT_VIEWPORT_MULTIPLIER,
+      MAX_DRAG_DISTANCE * EXIT_DRAG_MULTIPLIER,
+    );
 };
 
 const handlePointerDown = (event: PointerEvent) => {
-  if (props.pending) return;
+  if (isInteractionLocked.value || swipePhase.value !== "idle") return;
 
   const currentTarget = event.currentTarget;
   if (!(currentTarget instanceof HTMLElement)) return;
-
-  clearActionTimeout();
 
   const rect = currentTarget.getBoundingClientRect();
   const localY = Math.min(Math.max(event.clientY - rect.top, 0), rect.height);
@@ -213,6 +247,9 @@ const handlePointerDown = (event: PointerEvent) => {
     window.innerWidth * DISTANCE_THRESHOLD_RATIO,
   );
   settleTransition.value = REBOUND_TRANSITION;
+  pendingAction.value = null;
+  hasDispatchedExitAction.value = false;
+  swipePhase.value = "dragging";
 
   currentTarget.setPointerCapture(event.pointerId);
   activePointer.value = {
@@ -227,7 +264,13 @@ const handlePointerDown = (event: PointerEvent) => {
 
 const handlePointerMove = (event: PointerEvent) => {
   const pointer = activePointer.value;
-  if (!pointer || pointer.pointerId !== event.pointerId) return;
+  if (
+    !pointer ||
+    pointer.pointerId !== event.pointerId ||
+    swipePhase.value !== "dragging"
+  ) {
+    return;
+  }
 
   rawTranslateX.value = event.clientX - pointer.startX;
   translateX.value = applyDamping(rawTranslateX.value);
@@ -238,7 +281,7 @@ const handlePointerMove = (event: PointerEvent) => {
 const resolveSwipeAction = (
   offsetX: number,
   velocityX: number,
-): "skip" | "view-detail" | null => {
+): SwipeAction | null => {
   if (
     offsetX <= -swipeThreshold.value ||
     velocityX <= -FLICK_VELOCITY_THRESHOLD
@@ -258,7 +301,13 @@ const resolveSwipeAction = (
 
 const handlePointerUp = (event: PointerEvent) => {
   const pointer = activePointer.value;
-  if (!pointer || pointer.pointerId !== event.pointerId) return;
+  if (
+    !pointer ||
+    pointer.pointerId !== event.pointerId ||
+    swipePhase.value !== "dragging"
+  ) {
+    return;
+  }
 
   const timeDelta = Math.max(event.timeStamp - pointer.lastTimestamp, 1);
   const velocityX =
@@ -266,50 +315,85 @@ const handlePointerUp = (event: PointerEvent) => {
   const action = resolveSwipeAction(rawTranslateX.value, velocityX);
   activePointer.value = null;
 
-  if (action === "skip") {
-    settleTransition.value = EXIT_TRANSITION;
-    translateX.value = -Math.max(
-      window.innerWidth * EXIT_VIEWPORT_MULTIPLIER,
-      MAX_DRAG_DISTANCE * EXIT_DRAG_MULTIPLIER,
-    );
-    actionTimeoutId.value = window.setTimeout(() => {
-      actionTimeoutId.value = null;
-      emit("skip");
-      resetDrag();
-    }, ACTION_EMIT_DELAY_MS);
+  if (action === "view-detail" && props.detailPrId === null) {
+    startRebound();
     return;
   }
 
-  if (action === "view-detail" && props.detailPrId !== null) {
-    settleTransition.value = EXIT_TRANSITION;
-    translateX.value = Math.max(
-      window.innerWidth * EXIT_VIEWPORT_MULTIPLIER,
-      MAX_DRAG_DISTANCE * EXIT_DRAG_MULTIPLIER,
-    );
-    actionTimeoutId.value = window.setTimeout(() => {
-      actionTimeoutId.value = null;
-      emit("view-detail");
-      resetDrag();
-    }, ACTION_EMIT_DELAY_MS);
+  if (action) {
+    startExit(action);
     return;
   }
 
-  settleTransition.value = REBOUND_TRANSITION;
-  translateX.value = 0;
-  rawTranslateX.value = 0;
+  startRebound();
 };
 
 const handlePointerCancel = (event: PointerEvent) => {
   const pointer = activePointer.value;
   if (!pointer || pointer.pointerId !== event.pointerId) return;
-  activePointer.value = null;
-  settleTransition.value = REBOUND_TRANSITION;
-  translateX.value = 0;
-  rawTranslateX.value = 0;
+  startRebound();
 };
 
-onBeforeUnmount(() => {
-  clearActionTimeout();
+const handleTransitionEnd = (event: TransitionEvent) => {
+  if (
+    event.propertyName !== "transform" ||
+    event.target !== event.currentTarget
+  ) {
+    return;
+  }
+
+  if (swipePhase.value === "rebounding") {
+    resetCardState();
+    return;
+  }
+
+  if (
+    swipePhase.value !== "exiting" ||
+    pendingAction.value === null ||
+    hasDispatchedExitAction.value
+  ) {
+    return;
+  }
+
+  hasDispatchedExitAction.value = true;
+  if (pendingAction.value === "skip") {
+    emit("skip");
+    return;
+  }
+
+  emit("view-detail");
+};
+
+watch(
+  () => props.pending,
+  (isPending, wasPending) => {
+    if (
+      isPending ||
+      !wasPending ||
+      swipePhase.value !== "exiting" ||
+      pendingAction.value !== "view-detail" ||
+      !hasDispatchedExitAction.value
+    ) {
+      return;
+    }
+
+    startRebound();
+  },
+);
+
+watch(
+  () => [props.displayLocationName, props.timeLabel, props.detailPrId],
+  () => {
+    if (swipePhase.value !== "idle") {
+      resetCardState();
+    }
+  },
+);
+
+watch(() => props.pending, (isPending) => {
+  if (isPending && activePointer.value !== null) {
+    startRebound();
+  }
 });
 </script>
 

--- a/apps/frontend/src/pages/AnchorEventPage.vue
+++ b/apps/frontend/src/pages/AnchorEventPage.vue
@@ -78,6 +78,7 @@
               </article>
 
               <AnchorEventDemandCard
+                :key="activeDemandCard.cardKey"
                 class="card-stage__front"
                 :display-location-name="activeDemandCard.displayLocationName"
                 :time-label="activeDemandCard.timeLabel"


### PR DESCRIPTION
## Summary
- fix the Card mode front-card remount by adding `:key="activeDemandCard.cardKey"` to avoid transform state leaking into the next card
- refactor `AnchorEventDemandCard` swipe handling from timeout-based completion to a transitionend-driven state machine (`idle`/`dragging`/`exiting`/`rebounding`)
- lock interaction while pending or during rebound/exit to prevent double actions and mid-animation race conditions
- keep issue #34 content-personalization concerns out of this PR (animation fix only)

## Verification
- `pnpm --filter @partner-up-dev/frontend build`

## Notes
- right swipe behavior remains `view-detail`
- this PR addresses only the animation portion of #34

Refs #34
