### PR TITLE
Smooth Anchor Event card handoff after swipe

### DIFF
--- a/apps/frontend/src/domains/event/ui/primitives/AnchorEventDemandCard.vue
+++ b/apps/frontend/src/domains/event/ui/primitives/AnchorEventDemandCard.vue
@@ -4,6 +4,7 @@
     :class="{
       'demand-card--dragging': isDragging,
       'demand-card--pending': isPendingState,
+      'demand-card--preview': preview,
     }"
     :style="cardStyle"
     @pointerdown="handlePointerDown"
@@ -12,7 +13,7 @@
     @pointercancel="handlePointerCancel"
     @transitionend="handleTransitionEnd"
   >
-    <div class="demand-card__stamps" aria-hidden="true">
+    <div v-if="!preview" class="demand-card__stamps" aria-hidden="true">
       <span
         class="demand-card__stamp demand-card__stamp--like"
         :style="{ opacity: likeStampOpacity }"
@@ -62,7 +63,7 @@
         </p>
       </section>
 
-      <div class="demand-card__actions">
+      <div v-if="!preview" class="demand-card__actions">
         <button
           type="button"
           class="demand-card__action demand-card__action--skip"
@@ -122,11 +123,13 @@ const props = withDefaults(
     coverImage?: string | null;
     detailPrId?: number | null;
     pending?: boolean;
+    preview?: boolean;
   }>(),
   {
     coverImage: null,
     detailPrId: null,
     pending: false,
+    preview: false,
   },
 );
 
@@ -148,10 +151,11 @@ const hasDispatchedExitAction = ref(false);
 
 const isDragging = computed(() => swipePhase.value === "dragging");
 const isPendingState = computed(
-  () => props.pending || swipePhase.value === "exiting",
+  () => (!props.preview && props.pending) || swipePhase.value === "exiting",
 );
 const isInteractionLocked = computed(
   () =>
+    props.preview ||
     props.pending ||
     swipePhase.value === "exiting" ||
     swipePhase.value === "rebounding",
@@ -335,6 +339,10 @@ const handlePointerCancel = (event: PointerEvent) => {
 };
 
 const handleTransitionEnd = (event: TransitionEvent) => {
+  if (props.preview) {
+    return;
+  }
+
   if (
     event.propertyName !== "transform" ||
     event.target !== event.currentTarget
@@ -413,6 +421,18 @@ watch(() => props.pending, (isPending) => {
 
 .demand-card--pending {
   opacity: 0.9;
+}
+
+.demand-card--preview {
+  box-shadow: var(--sys-shadow-2);
+}
+
+.demand-card--preview .demand-card__cover {
+  filter: saturate(0.85) brightness(0.9);
+}
+
+.demand-card--preview .demand-card__content {
+  gap: var(--sys-spacing-sm);
 }
 
 .demand-card__stamps {

--- a/apps/frontend/src/pages/AnchorEventPage.vue
+++ b/apps/frontend/src/pages/AnchorEventPage.vue
@@ -51,44 +51,35 @@
         <div v-if="activeDemandCard" class="card-mode">
           <div class="card-stage">
             <div class="card-stage__inner">
-              <article
-                v-if="nextDemandCard"
-                class="card-stack-preview"
-                aria-hidden="true"
-              >
-                <div
-                  v-if="nextDemandCard.coverImage"
-                  class="card-stack-preview__cover"
-                  :style="{
-                    backgroundImage: `url(${nextDemandCard.coverImage})`,
-                  }"
-                />
-                <div
-                  v-else
-                  class="card-stack-preview__cover card-stack-preview__cover--fallback"
-                />
-                <div class="card-stack-preview__content">
-                  <p class="card-stack-preview__time">
-                    {{ nextDemandCard.timeLabel }}
-                  </p>
-                  <p class="card-stack-preview__title">
-                    {{ nextDemandCard.displayLocationName }}
-                  </p>
-                </div>
-              </article>
-
               <AnchorEventDemandCard
-                :key="activeDemandCard.cardKey"
-                class="card-stage__front"
-                :display-location-name="activeDemandCard.displayLocationName"
-                :time-label="activeDemandCard.timeLabel"
-                :preference-tags="activeDemandCard.preferenceTags"
-                :cover-image="activeDemandCard.coverImage"
-                :detail-pr-id="activeDemandCard.detailPrId"
-                :pending="isCardRouting"
-                @skip="handleSkipActiveCard"
-                @view-detail="handleViewActiveCardDetail"
+                v-if="nextDemandCard"
+                :key="`preview-${nextDemandCard.cardKey}`"
+                class="card-stack-preview"
+                :display-location-name="nextDemandCard.displayLocationName"
+                :time-label="nextDemandCard.timeLabel"
+                :preference-tags="nextDemandCard.preferenceTags"
+                :cover-image="nextDemandCard.coverImage"
+                :detail-pr-id="nextDemandCard.detailPrId"
+                :preview="true"
+                aria-hidden="true"
               />
+
+              <div
+                :key="`front-${activeDemandCard.cardKey}`"
+                class="card-stage__front-shell"
+              >
+                <AnchorEventDemandCard
+                  class="card-stage__front"
+                  :display-location-name="activeDemandCard.displayLocationName"
+                  :time-label="activeDemandCard.timeLabel"
+                  :preference-tags="activeDemandCard.preferenceTags"
+                  :cover-image="activeDemandCard.coverImage"
+                  :detail-pr-id="activeDemandCard.detailPrId"
+                  :pending="isCardRouting"
+                  @skip="handleSkipActiveCard"
+                  @view-detail="handleViewActiveCardDetail"
+                />
+              </div>
             </div>
           </div>
 
@@ -1034,6 +1025,13 @@ const formatLocationOptionLabel = (option: LocationOption): string => {
   min-height: var(--dcs-layout-anchor-card-stage-height);
 }
 
+.card-stage__front-shell {
+  position: absolute;
+  inset: 0;
+  z-index: 2;
+  animation: card-front-promote 220ms cubic-bezier(0.16, 1, 0.3, 1);
+}
+
 .card-stage__front {
   z-index: 2;
 }
@@ -1042,46 +1040,27 @@ const formatLocationOptionLabel = (option: LocationOption): string => {
   position: absolute;
   inset: 0;
   transform: translateY(14px) scale(0.972);
-  border-radius: var(--dcs-surface-panel-radius-large);
-  overflow: hidden;
-  border: 1px solid var(--sys-color-outline-variant);
-  box-shadow: var(--sys-shadow-2);
   z-index: 1;
   pointer-events: none;
+  animation: card-preview-reveal 220ms ease-out 90ms both;
 }
 
-.card-stack-preview__cover {
-  height: 60%;
-  background-size: cover;
-  background-position: center;
-  filter: saturate(0.85) brightness(0.9);
+@keyframes card-front-promote {
+  from {
+    transform: translateY(14px) scale(0.972);
+  }
+  to {
+    transform: translateY(0) scale(1);
+  }
 }
 
-.card-stack-preview__cover--fallback {
-  background: linear-gradient(
-    140deg,
-    var(--sys-color-surface-container-high),
-    var(--sys-color-surface-container)
-  );
-}
-
-.card-stack-preview__content {
-  padding: var(--sys-spacing-sm) var(--sys-spacing-med) var(--sys-spacing-med);
-  display: flex;
-  flex-direction: column;
-  gap: var(--sys-spacing-xs);
-}
-
-.card-stack-preview__time {
-  @include mx.pu-font(label-medium);
-  margin: 0;
-  color: var(--sys-color-on-surface-variant);
-}
-
-.card-stack-preview__title {
-  @include mx.pu-font(title-large);
-  margin: 0;
-  color: var(--sys-color-on-surface);
+@keyframes card-preview-reveal {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
 }
 
 .card-mode__error {


### PR DESCRIPTION
## Summary
- follow up after merged PR #78 to smooth the card handoff in `/events/:eventId` Card mode
- replace custom preview markup with `AnchorEventDemandCard` in preview mode so the underlay card matches the real upcoming card
- add a short front-card promote animation to reduce the abrupt "flash-in" effect when the next card becomes active
- keep scope focused on animation/transition behavior only (no content-personalization changes)

## Verification
- `pnpm --filter @partner-up-dev/frontend build`

## Context
- PR #78 was merged from head `4d952d0`; this PR contains the follow-up commit that was pushed after that merge

Refs #34
