### PR TITLE
Polish card browsing UX: CTA copy, flick sensitivity, depth stack

### DIFF
--- a/apps/frontend/src/domains/event/ui/primitives/AnchorEventDemandCard.vue
+++ b/apps/frontend/src/domains/event/ui/primitives/AnchorEventDemandCard.vue
@@ -94,22 +94,29 @@ import { useI18n } from "vue-i18n";
 const MAX_DRAG_DISTANCE = 260;
 const MIN_DISTANCE_THRESHOLD = 96;
 const DISTANCE_THRESHOLD_RATIO = 0.34;
-const FLICK_VELOCITY_THRESHOLD = 900;
+const FLICK_VELOCITY_THRESHOLD = 760;
+const FLICK_MIN_DISTANCE = 22;
 const ROTATION_DIVISOR = 22;
 const MAX_ROTATION_DEG = 18;
 const EXIT_TRANSITION = "transform 280ms cubic-bezier(0.16, 1, 0.3, 1)";
 const REBOUND_TRANSITION = "transform 440ms cubic-bezier(0.22, 1.35, 0.36, 1)";
 const MILLISECONDS_PER_SECOND = 1000;
+const VELOCITY_SAMPLE_WINDOW_MS = 90;
+const MAX_VELOCITY_SAMPLES = 8;
 const EXIT_VIEWPORT_MULTIPLIER = 1.1;
 const EXIT_DRAG_MULTIPLIER = 1.5;
+
+type MotionSample = {
+  x: number;
+  timestamp: number;
+};
 
 type PointerState = {
   pointerId: number;
   startX: number;
-  lastX: number;
-  lastTimestamp: number;
   tiltDirectionFactor: number;
   pivotY: number;
+  motionSamples: MotionSample[];
 };
 
 type SwipeAction = "skip" | "view-detail";
@@ -198,6 +205,37 @@ const applyDamping = (offsetX: number): number => {
   return sign * damped;
 };
 
+const appendMotionSample = (
+  pointer: PointerState,
+  x: number,
+  timestamp: number,
+) => {
+  pointer.motionSamples.push({ x, timestamp });
+  const sampleWindowStart = timestamp - VELOCITY_SAMPLE_WINDOW_MS * 2;
+  pointer.motionSamples = pointer.motionSamples
+    .filter((sample) => sample.timestamp >= sampleWindowStart)
+    .slice(-MAX_VELOCITY_SAMPLES);
+};
+
+const resolveVelocityX = (
+  pointer: PointerState,
+  endX: number,
+  endTimestamp: number,
+): number => {
+  const samples = [
+    ...pointer.motionSamples,
+    { x: endX, timestamp: endTimestamp },
+  ].sort((left, right) => left.timestamp - right.timestamp);
+  const windowStart = endTimestamp - VELOCITY_SAMPLE_WINDOW_MS;
+  const earliestWindowSample =
+    samples.find((sample) => sample.timestamp >= windowStart) ?? samples[0];
+
+  const timeDelta = Math.max(endTimestamp - earliestWindowSample.timestamp, 1);
+  return (
+    ((endX - earliestWindowSample.x) / timeDelta) * MILLISECONDS_PER_SECOND
+  );
+};
+
 const resetCardState = () => {
   activePointer.value = null;
   translateX.value = 0;
@@ -259,10 +297,9 @@ const handlePointerDown = (event: PointerEvent) => {
   activePointer.value = {
     pointerId: event.pointerId,
     startX: event.clientX,
-    lastX: event.clientX,
-    lastTimestamp: event.timeStamp,
     tiltDirectionFactor,
     pivotY: localY,
+    motionSamples: [{ x: event.clientX, timestamp: event.timeStamp }],
   };
 };
 
@@ -278,24 +315,28 @@ const handlePointerMove = (event: PointerEvent) => {
 
   rawTranslateX.value = event.clientX - pointer.startX;
   translateX.value = applyDamping(rawTranslateX.value);
-  pointer.lastX = event.clientX;
-  pointer.lastTimestamp = event.timeStamp;
+  appendMotionSample(pointer, event.clientX, event.timeStamp);
 };
 
 const resolveSwipeAction = (
   offsetX: number,
   velocityX: number,
 ): SwipeAction | null => {
+  const isFastSkipGesture =
+    velocityX <= -FLICK_VELOCITY_THRESHOLD && offsetX <= -FLICK_MIN_DISTANCE;
+  const isFastDetailGesture =
+    velocityX >= FLICK_VELOCITY_THRESHOLD && offsetX >= FLICK_MIN_DISTANCE;
+
   if (
     offsetX <= -swipeThreshold.value ||
-    velocityX <= -FLICK_VELOCITY_THRESHOLD
+    isFastSkipGesture
   ) {
     return "skip";
   }
 
   if (
     offsetX >= swipeThreshold.value ||
-    velocityX >= FLICK_VELOCITY_THRESHOLD
+    isFastDetailGesture
   ) {
     return "view-detail";
   }
@@ -313,9 +354,7 @@ const handlePointerUp = (event: PointerEvent) => {
     return;
   }
 
-  const timeDelta = Math.max(event.timeStamp - pointer.lastTimestamp, 1);
-  const velocityX =
-    ((event.clientX - pointer.lastX) / timeDelta) * MILLISECONDS_PER_SECOND;
+  const velocityX = resolveVelocityX(pointer, event.clientX, event.timeStamp);
   const action = resolveSwipeAction(rawTranslateX.value, velocityX);
   activePointer.value = null;
 

--- a/apps/frontend/src/locales/zh-CN.jsonc
+++ b/apps/frontend/src/locales/zh-CN.jsonc
@@ -1003,7 +1003,7 @@
       "preferenceTitle": "偏好",
       "preferenceEmpty": "暂无额外偏好要求",
       "skipButton": "跳过",
-      "detailButton": "查看详情",
+      "detailButton": "加入",
       "emptyTitle": "卡片已看完",
       "emptySubtitle": "还没有合适的局？可以直接创建一个。"
     },

--- a/apps/frontend/src/pages/AnchorEventPage.vue
+++ b/apps/frontend/src/pages/AnchorEventPage.vue
@@ -52,14 +52,18 @@
           <div class="card-stage">
             <div class="card-stage__inner">
               <AnchorEventDemandCard
-                v-if="nextDemandCard"
-                :key="`preview-${nextDemandCard.cardKey}`"
+                v-for="(previewCard, previewIndex) in stackPreviewCards"
+                :key="`preview-${previewCard.cardKey}`"
                 class="card-stack-preview"
-                :display-location-name="nextDemandCard.displayLocationName"
-                :time-label="nextDemandCard.timeLabel"
-                :preference-tags="nextDemandCard.preferenceTags"
-                :cover-image="nextDemandCard.coverImage"
-                :detail-pr-id="nextDemandCard.detailPrId"
+                :style="{
+                  '--card-stack-depth': String(previewIndex + 1),
+                  zIndex: 2 - previewIndex,
+                }"
+                :display-location-name="previewCard.displayLocationName"
+                :time-label="previewCard.timeLabel"
+                :preference-tags="previewCard.preferenceTags"
+                :cover-image="previewCard.coverImage"
+                :detail-pr-id="previewCard.detailPrId"
                 :preview="true"
                 aria-hidden="true"
               />
@@ -641,7 +645,7 @@ const remainingDemandCards = computed(() =>
 );
 
 const activeDemandCard = computed(() => remainingDemandCards.value[0] ?? null);
-const nextDemandCard = computed(() => remainingDemandCards.value[1] ?? null);
+const stackPreviewCards = computed(() => remainingDemandCards.value.slice(1, 3));
 
 watch(activeDemandCard, () => {
   cardActionError.value = null;
@@ -1028,7 +1032,7 @@ const formatLocationOptionLabel = (option: LocationOption): string => {
 .card-stage__front-shell {
   position: absolute;
   inset: 0;
-  z-index: 2;
+  z-index: 3;
   animation: card-front-promote 220ms cubic-bezier(0.16, 1, 0.3, 1);
 }
 
@@ -1037,12 +1041,17 @@ const formatLocationOptionLabel = (option: LocationOption): string => {
 }
 
 .card-stack-preview {
+  --card-stack-depth: 1;
   position: absolute;
   inset: 0;
-  transform: translateY(14px) scale(0.972);
-  z-index: 1;
+  transform:
+    translateY(calc(14px + (var(--card-stack-depth) - 1) * 12px))
+    scale(calc(0.972 - (var(--card-stack-depth) - 1) * 0.028));
+  transform-origin: center top;
+  opacity: calc(1 - (var(--card-stack-depth) - 1) * 0.12);
   pointer-events: none;
-  animation: card-preview-reveal 220ms ease-out 90ms both;
+  animation: card-preview-reveal 220ms ease-out both;
+  animation-delay: calc(70ms + (var(--card-stack-depth) - 1) * 40ms);
 }
 
 @keyframes card-front-promote {


### PR DESCRIPTION
## Summary
- update Card mode CTA copy from `查看详情` to `加入`, while keeping the action behavior unchanged (still routes to Anchor PR detail page)
- improve flick sensitivity in swipe gesture resolution by using a short velocity sampling window instead of only the final pointer segment
- tune swipe thresholds so fast horizontal flicks trigger reliably even when displacement is below the distance threshold
- render stacked preview cards (up to two) with depth-based vertical offsets and scaling so users can perceive queue depth before swiping
- keep the front-card promotion animation aligned with the first preview depth for smoother handoff

## Verification
- `pnpm --filter @partner-up-dev/frontend build`

## Notes
- scope is limited to card browsing UX in `/events/:eventId` Card mode
- no backend/API contract changes

Refs #34
