### PR TITLE
fix: booking-support visibility and join modal spacing regressions

### DIFF
--- a/apps/backend/src/domains/pr-booking-support/use-cases/get-anchor-pr-booking-support.ts
+++ b/apps/backend/src/domains/pr-booking-support/use-cases/get-anchor-pr-booking-support.ts
@@ -21,6 +21,7 @@ export interface AnchorPRBookingSupportDetail {
   status: PRStatus;
   anchorEventId: number;
   batchId: number;
+  viewerIsCreator: boolean;
   bookingSupport: {
     overview: {
       title: string;
@@ -91,6 +92,7 @@ export async function getAnchorPRBookingSupport(
     status: root.status,
     anchorEventId: anchor.anchorEventId,
     batchId: anchor.batchId,
+    viewerIsCreator: Boolean(root.createdBy && root.createdBy === viewerUserId),
     bookingSupport: {
       overview: {
         title: "预订与资助",

--- a/apps/frontend/src/pages/AnchorPRBookingSupportPage.vue
+++ b/apps/frontend/src/pages/AnchorPRBookingSupportPage.vue
@@ -41,7 +41,10 @@
       </section>
 
       <section
-        v-if="bookingSupportDetail.bookingSupport.bookingContact.required"
+        v-if="
+          bookingSupportDetail.bookingSupport.bookingContact.required &&
+          bookingSupportDetail.viewerIsCreator
+        "
         class="card"
       >
         <h2 class="card-title">{{ t("prBookingSupport.bookingContact.title") }}</h2>

--- a/apps/frontend/src/pages/AnchorPRPage.vue
+++ b/apps/frontend/src/pages/AnchorPRPage.vue
@@ -298,31 +298,33 @@
         </template>
 
         <template v-else>
-          <p class="modal-text">当前加入需要你先填写预订联系人手机号。</p>
-          <input
-            v-model.trim="joinFlowPhoneInput"
-            class="modal-phone-input"
-            type="tel"
-            inputmode="numeric"
-            maxlength="11"
-            placeholder="请输入 11 位大陆手机号"
-          />
-          <div class="modal-actions">
-            <button
-              class="action-btn action-btn--surface"
-              type="button"
-              @click="closeJoinFlowModal"
-            >
-              {{ t("common.cancel") }}
-            </button>
-            <button
-              class="action-btn"
-              type="button"
-              :disabled="joinFlowPending"
-              @click="submitJoinFlowPhoneAndJoin"
-            >
-              {{ joinFlowPending ? t("prPage.joining") : "填写并加入" }}
-            </button>
+          <div class="join-phone-step">
+            <p class="modal-text">当前加入需要你先填写预订联系人手机号。</p>
+            <input
+              v-model.trim="joinFlowPhoneInput"
+              class="modal-phone-input"
+              type="tel"
+              inputmode="numeric"
+              maxlength="11"
+              placeholder="请输入 11 位大陆手机号"
+            />
+            <div class="modal-actions">
+              <button
+                class="action-btn action-btn--surface"
+                type="button"
+                @click="closeJoinFlowModal"
+              >
+                {{ t("common.cancel") }}
+              </button>
+              <button
+                class="action-btn"
+                type="button"
+                :disabled="joinFlowPending"
+                @click="submitJoinFlowPhoneAndJoin"
+              >
+                {{ joinFlowPending ? t("prPage.joining") : "填写并加入" }}
+              </button>
+            </div>
           </div>
         </template>
         <p v-if="joinFlowError" class="action-error">{{ joinFlowError }}</p>
@@ -1391,6 +1393,16 @@ const reimbursementReasonText = (
   @include mx.pu-font(body-medium);
   background: var(--sys-color-surface);
   color: var(--sys-color-on-surface);
+}
+
+.join-phone-step {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sys-spacing-sm);
+}
+
+.join-phone-step .modal-text {
+  margin: 0;
 }
 
 .modal-actions {


### PR DESCRIPTION
## Fixes
- Booking-support page: booking-contact phone card is now visible only when current viewer is APR creator.
- Join modal: adjusted phone step layout spacing between input and bottom action buttons using existing spacing tokens.

## Changes
- Backend: add `viewerIsCreator` flag in booking-support detail payload.
- Frontend: use `viewerIsCreator` to gate booking-contact card rendering.
- Frontend: wrap join phone step with `join-phone-step` flex container and `gap: var(--sys-spacing-sm)`.

## Verification
- `pnpm --filter @partner-up-dev/backend typecheck`
- `pnpm --filter @partner-up-dev/frontend build`