### PR TITLE
fix(backend): set creator for creatorless anchor on first join

### DIFF
--- a/apps/backend/src/domains/admin-anchor-management/use-cases/release-admin-anchor-pr-partner.ts
+++ b/apps/backend/src/domains/admin-anchor-management/use-cases/release-admin-anchor-pr-partner.ts
@@ -1,22 +1,18 @@
 import { HTTPException } from "hono/http-exception";
 import type { PartnerId, PRId, UserId } from "../../../entities";
-import { AnchorPRBookingContactRepository } from "../../../repositories/AnchorPRBookingContactRepository";
 import { AnchorPRRepository } from "../../../repositories/AnchorPRRepository";
 import { PartnerRepository } from "../../../repositories/PartnerRepository";
-import { PartnerRequestRepository } from "../../../repositories/PartnerRequestRepository";
 import { UserReliabilityRepository } from "../../../repositories/UserReliabilityRepository";
 import { cancelWeChatReminderJobsForParticipant } from "../../../infra/notifications";
 import { recalculatePRStatus } from "../../pr-core/services/slot-management.service";
 import { syncAnchorBookingTriggeredState } from "../../pr-core/services/anchor-booking-trigger.service";
-import { resolveBookingContactState } from "../../pr-booking-support";
 import { eventBus, writeToOutbox } from "../../../infra/events";
 import { operationLogService } from "../../../infra/operation-log";
+import { applyAnchorParticipantReleaseEffects } from "../../pr-core/services/anchor-participant-release-effects.service";
 
 const anchorPRRepo = new AnchorPRRepository();
-const prRepo = new PartnerRequestRepository();
 const partnerRepo = new PartnerRepository();
 const userReliabilityRepo = new UserReliabilityRepository();
-const bookingContactRepo = new AnchorPRBookingContactRepository();
 
 const isReleaseableStatus = (status: string): boolean =>
   status === "JOINED" || status === "CONFIRMED";
@@ -66,28 +62,14 @@ export async function releaseAdminAnchorPRPartner(input: {
   await userReliabilityRepo.applyDelta(slot.userId, { released: 1 });
   await cancelWeChatReminderJobsForParticipant(input.prId, slot.userId);
 
-  const bookingContact = await bookingContactRepo.findByPrId(input.prId);
-  const bookingContactCleared =
-    bookingContact !== null && bookingContact.ownerPartnerId === releasedSlot.id;
-  if (bookingContactCleared) {
-    await bookingContactRepo.deleteByPrId(input.prId);
-  }
-
-  let creatorTransferredToUserId = record.root.createdBy ?? null;
-  if (record.root.createdBy && record.root.createdBy === slot.userId) {
-    const activeParticipants =
-      await partnerRepo.listActiveParticipantSummariesByPrId(input.prId);
-    const successor = activeParticipants[0] ?? null;
-    creatorTransferredToUserId = successor?.userId ?? null;
-    await prRepo.setCreatedBy(input.prId, creatorTransferredToUserId);
-  }
+  const { bookingContactCleared, creatorTransferredToUserId } =
+    await applyAnchorParticipantReleaseEffects({
+      prId: input.prId,
+      releasedUserIds: [slot.userId],
+    });
 
   await recalculatePRStatus(input.prId);
   await syncAnchorBookingTriggeredState(input.prId);
-  await resolveBookingContactState({
-    prId: input.prId,
-    viewerUserId: null,
-  });
 
   const event = await eventBus.publish(
     "partner.slot_released",

--- a/apps/backend/src/domains/pr-booking-support/use-cases/get-anchor-pr-booking-support.ts
+++ b/apps/backend/src/domains/pr-booking-support/use-cases/get-anchor-pr-booking-support.ts
@@ -21,7 +21,6 @@ export interface AnchorPRBookingSupportDetail {
   status: PRStatus;
   anchorEventId: number;
   batchId: number;
-  viewerIsCreator: boolean;
   bookingSupport: {
     overview: {
       title: string;
@@ -92,7 +91,6 @@ export async function getAnchorPRBookingSupport(
     status: root.status,
     anchorEventId: anchor.anchorEventId,
     batchId: anchor.batchId,
-    viewerIsCreator: Boolean(root.createdBy && root.createdBy === viewerUserId),
     bookingSupport: {
       overview: {
         title: "预订与资助",

--- a/apps/backend/src/domains/pr-core/services/anchor-participant-release-effects.service.ts
+++ b/apps/backend/src/domains/pr-core/services/anchor-participant-release-effects.service.ts
@@ -1,0 +1,54 @@
+import type { PRId, UserId } from "../../../entities";
+import { AnchorPRBookingContactRepository } from "../../../repositories/AnchorPRBookingContactRepository";
+import { PartnerRepository } from "../../../repositories/PartnerRepository";
+import { PartnerRequestRepository } from "../../../repositories/PartnerRequestRepository";
+import { resolveBookingContactState } from "../../pr-booking-support";
+
+const prRepo = new PartnerRequestRepository();
+const partnerRepo = new PartnerRepository();
+const bookingContactRepo = new AnchorPRBookingContactRepository();
+
+export type AnchorParticipantReleaseEffects = {
+  creatorTransferredToUserId: UserId | null;
+  creatorTransferApplied: boolean;
+  bookingContactCleared: boolean;
+};
+
+export const applyAnchorParticipantReleaseEffects = async (input: {
+  prId: PRId;
+  releasedUserIds: UserId[];
+}): Promise<AnchorParticipantReleaseEffects> => {
+  const request = await prRepo.findById(input.prId);
+  if (!request || request.prKind !== "ANCHOR") {
+    return {
+      creatorTransferredToUserId: null,
+      creatorTransferApplied: false,
+      bookingContactCleared: false,
+    };
+  }
+
+  let creatorTransferredToUserId = request.createdBy ?? null;
+  let creatorTransferApplied = false;
+  if (request.createdBy && input.releasedUserIds.includes(request.createdBy)) {
+    const activeParticipants =
+      await partnerRepo.listActiveParticipantSummariesByPrId(input.prId);
+    const successor = activeParticipants[0] ?? null;
+    creatorTransferredToUserId = successor?.userId ?? null;
+    await prRepo.setCreatedBy(input.prId, creatorTransferredToUserId);
+    creatorTransferApplied = true;
+  }
+
+  const existingBookingContact = await bookingContactRepo.findByPrId(input.prId);
+  await resolveBookingContactState({
+    prId: input.prId,
+    viewerUserId: null,
+  });
+  const latestBookingContact = await bookingContactRepo.findByPrId(input.prId);
+
+  return {
+    creatorTransferredToUserId,
+    creatorTransferApplied,
+    bookingContactCleared:
+      existingBookingContact !== null && latestBookingContact === null,
+  };
+};

--- a/apps/backend/src/domains/pr-core/temporal-refresh.ts
+++ b/apps/backend/src/domains/pr-core/temporal-refresh.ts
@@ -28,8 +28,8 @@ import {
 import { cancelWeChatReminderJobsForParticipant } from "../../infra/notifications";
 import { operationLogService } from "../../infra/operation-log";
 import { getEffectiveBookingDeadline } from "../pr-booking-support";
-import { resolveBookingContactState } from "../pr-booking-support";
 import { syncAnchorBookingTriggeredState } from "./services/anchor-booking-trigger.service";
+import { applyAnchorParticipantReleaseEffects } from "./services/anchor-participant-release-effects.service";
 
 const prRepo = new PartnerRequestRepository();
 const partnerRepo = new PartnerRepository();
@@ -207,6 +207,7 @@ async function releaseUnconfirmedSlotsIfNeeded(
   const participants = await listActiveParticipantSummariesForPR(request.id);
   const releasing = participants.filter((slot) => slot.status === "JOINED");
   if (releasing.length === 0) return;
+  const releasedUserIds = releasing.map((slot) => slot.userId);
 
   for (const slot of releasing) {
     await userReliabilityRepo.applyDelta(slot.userId, { released: 1 });
@@ -227,9 +228,9 @@ async function releaseUnconfirmedSlotsIfNeeded(
 
   await recalculatePRStatus(request.id);
   if (request.prKind === "ANCHOR") {
-    await resolveBookingContactState({
+    await applyAnchorParticipantReleaseEffects({
       prId: request.id,
-      viewerUserId: null,
+      releasedUserIds,
     });
   }
 }

--- a/apps/backend/src/domains/pr-core/use-cases/join-pr.ts
+++ b/apps/backend/src/domains/pr-core/use-cases/join-pr.ts
@@ -190,14 +190,6 @@ export async function joinPRAsUser(
 
   if (
     refreshedRequest.prKind === "ANCHOR" &&
-    refreshedRequest.createdBy === null &&
-    activeCount === 0
-  ) {
-    await prRepo.setCreatedBy(id, user.id);
-  }
-
-  if (
-    refreshedRequest.prKind === "ANCHOR" &&
     bookingContactRequired &&
     activeCount === 0 &&
     bookingContactPhoneInput

--- a/apps/frontend/src/pages/AnchorPRBookingSupportPage.vue
+++ b/apps/frontend/src/pages/AnchorPRBookingSupportPage.vue
@@ -43,7 +43,7 @@
       <section
         v-if="
           bookingSupportDetail.bookingSupport.bookingContact.required &&
-          bookingSupportDetail.viewerIsCreator
+          bookingSupportDetail.bookingSupport.bookingContact.ownerIsCurrentViewer
         "
         class="card"
       >


### PR DESCRIPTION
## Summary
- assign createdBy when an anchor APR has no creator and the first active partner joins
- keep existing booking-contact first-join phone enforcement behavior unchanged

## Why
- ViewerIsCreator is derived from root.createdBy
- creatorless anchor APRs made first joiners fail owner-only UI checks on booking-support

## Validation
- pnpm --filter @partner-up-dev/backend typecheck
- pnpm --filter @partner-up-dev/frontend build