### PR TITLE
Move Card mode actions below swipe area

### DIFF
--- a/apps/frontend/src/domains/event/ui/primitives/AnchorEventDemandCard.vue
+++ b/apps/frontend/src/domains/event/ui/primitives/AnchorEventDemandCard.vue
@@ -63,26 +63,6 @@
         </p>
       </section>
 
-      <div v-if="!preview" class="demand-card__actions">
-        <button
-          type="button"
-          class="demand-card__action demand-card__action--skip"
-          :disabled="isInteractionLocked"
-          @pointerdown.stop
-          @click="emit('skip')"
-        >
-          {{ t("anchorEvent.card.skipButton") }}
-        </button>
-        <button
-          type="button"
-          class="demand-card__action demand-card__action--detail"
-          :disabled="isInteractionLocked || detailPrId === null"
-          @pointerdown.stop
-          @click="emit('view-detail')"
-        >
-          {{ t("anchorEvent.card.detailButton") }}
-        </button>
-      </div>
     </div>
   </article>
 </template>
@@ -633,32 +613,4 @@ watch(() => props.pending, (isPending) => {
   color: var(--sys-color-on-surface-variant);
 }
 
-.demand-card__actions {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: var(--sys-spacing-sm);
-}
-
-.demand-card__action {
-  @include mx.pu-pill-action(outline-transparent, default);
-  border: none;
-  cursor: pointer;
-  min-height: 48px;
-}
-
-.demand-card__action:disabled {
-  opacity: 0.45;
-  cursor: not-allowed;
-}
-
-.demand-card__action--detail {
-  background: var(--sys-color-primary);
-  color: var(--sys-color-on-primary);
-  border-color: var(--sys-color-primary);
-}
-
-.demand-card__action--skip {
-  color: var(--sys-color-error);
-  border-color: var(--sys-color-error);
-}
 </style>

--- a/apps/frontend/src/pages/AnchorEventPage.vue
+++ b/apps/frontend/src/pages/AnchorEventPage.vue
@@ -88,6 +88,25 @@
             </div>
           </div>
 
+          <div class="card-mode__actions">
+            <button
+              type="button"
+              class="card-mode__action card-mode__action--skip"
+              :disabled="isCardRouting"
+              @click="handleSkipActiveCard"
+            >
+              {{ t("anchorEvent.card.skipButton") }}
+            </button>
+            <button
+              type="button"
+              class="card-mode__action card-mode__action--detail"
+              :disabled="isCardRouting || activeDemandCard.detailPrId === null"
+              @click="handleViewActiveCardDetail"
+            >
+              {{ t("anchorEvent.card.detailButton") }}
+            </button>
+          </div>
+
           <p v-if="cardActionError" class="card-mode__error">
             {{ cardActionError }}
           </p>
@@ -1072,6 +1091,37 @@ const formatLocationOptionLabel = (option: LocationOption): string => {
   color: var(--sys-color-error);
   padding-inline-start: calc(var(--sys-spacing-med) + var(--pu-safe-left));
   padding-inline-end: calc(var(--sys-spacing-med) + var(--pu-safe-right));
+}
+
+.card-mode__actions {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--sys-spacing-sm);
+  padding-inline-start: calc(var(--sys-spacing-med) + var(--pu-safe-left));
+  padding-inline-end: calc(var(--sys-spacing-med) + var(--pu-safe-right));
+}
+
+.card-mode__action {
+  @include mx.pu-pill-action(outline-transparent, default);
+  border: none;
+  cursor: pointer;
+  min-height: 48px;
+}
+
+.card-mode__action:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.card-mode__action--detail {
+  background: var(--sys-color-primary);
+  color: var(--sys-color-on-primary);
+  border-color: var(--sys-color-primary);
+}
+
+.card-mode__action--skip {
+  color: var(--sys-color-error);
+  border-color: var(--sys-color-error);
 }
 
 .card-empty {


### PR DESCRIPTION
## Summary
- remove in-card action buttons from `AnchorEventDemandCard` so controls no longer "pop in" when a preview card becomes active
- add a stable action bar under the card browsing stage in `AnchorEventPage` with the same actions (`跳过` / `加入`)
- keep swipe gesture behavior unchanged; only button placement and rendering context are updated

## UX impact
- controls are always visible in a fixed location while browsing cards
- avoids abrupt appearance/disappearance tied to card promotion

## Verification
- `pnpm --filter @partner-up-dev/frontend build`

Refs #34
