### PR TITLE
fix(frontend): simplify NL form hints and prevent voice-button text selection

### DIFF
--- a/apps/frontend/src/domains/pr/ui/forms/NLPRForm.vue
+++ b/apps/frontend/src/domains/pr/ui/forms/NLPRForm.vue
@@ -10,14 +10,6 @@
         />
         <div class="nl-actions">
           <button
-            type="button"
-            class="ghost-action"
-            @click="applyExample"
-            :disabled="isSubmitting"
-          >
-            {{ t("nlForm.useExample") }}
-          </button>
-          <button
             v-if="isVoiceSupported"
             type="button"
             class="voice-action"
@@ -185,10 +177,6 @@ const onSubmit = async () => {
   await submitHandler();
 };
 
-const applyExample = () => {
-  setFieldValue("rawText", placeholderText.value);
-};
-
 const handleVoicePressStart = async () => {
   if (!isVoiceSupported.value || isSubmitting.value) return;
   try {
@@ -228,22 +216,8 @@ const handleVoicePressCancel = async () => {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  justify-content: space-between;
+  justify-content: flex-end;
   gap: var(--sys-spacing-xs);
-}
-
-.ghost-action {
-  @include mx.pu-font(label-medium);
-  color: var(--sys-color-primary);
-  background: transparent;
-  border: none;
-  padding: 0;
-  cursor: pointer;
-
-  &:disabled {
-    opacity: var(--sys-opacity-disabled);
-    cursor: not-allowed;
-  }
 }
 
 .voice-action {
@@ -261,6 +235,9 @@ const handleVoicePressCancel = async () => {
     transparent
   );
   color: var(--sys-color-on-primary-container);
+  user-select: none;
+  -webkit-user-select: none;
+  -webkit-touch-callout: none;
   cursor: pointer;
   transition:
     background-color 180ms ease,

--- a/apps/frontend/src/domains/pr/ui/sections/InlineNLPRForm.vue
+++ b/apps/frontend/src/domains/pr/ui/sections/InlineNLPRForm.vue
@@ -52,19 +52,6 @@
           ></span>
         </button>
       </div>
-    <div class="row row--actions">
-      <button
-        type="button"
-        class="ghost-action"
-        :disabled="isSubmitting"
-        @click="applyExample"
-      >
-        {{ t("nlForm.useExample") }}
-      </button>
-      <span v-if="isVoiceSupported" class="voice-hint">{{
-        t("nlForm.voiceHint")
-      }}</span>
-    </div>
     <p v-if="voiceErrorMessage" class="error-message voice-error">
       {{ voiceErrorMessage }}
     </p>
@@ -208,10 +195,6 @@ const onSubmit = async () => {
   await submitHandler();
 };
 
-const applyExample = () => {
-  setFieldValue("rawText", placeholderText.value);
-};
-
 const handleVoicePressStart = async () => {
   if (!isVoiceSupported.value || isSubmitting.value) return;
   if (isVoiceProcessing.value) return;
@@ -351,6 +334,9 @@ const handleVoicePressCancel = async () => {
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  user-select: none;
+  -webkit-user-select: none;
+  -webkit-touch-callout: none;
   cursor: pointer;
   transition:
     opacity 180ms ease,
@@ -374,33 +360,6 @@ const handleVoicePressCancel = async () => {
 
 .voice-icon {
   @include mx.pu-icon(small, true);
-}
-
-.row--actions {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: var(--sys-spacing-xs);
-  flex-basis: 100%;
-}
-
-.ghost-action {
-  @include mx.pu-font(label-medium);
-  color: var(--sys-color-primary);
-  background: transparent;
-  border: none;
-  padding: 0;
-  cursor: pointer;
-
-  &:disabled {
-    opacity: var(--sys-opacity-disabled);
-    cursor: not-allowed;
-  }
-}
-
-.voice-hint {
-  @include mx.pu-font(label-small);
-  color: var(--sys-color-on-surface-variant);
 }
 
 .error-message {


### PR DESCRIPTION
### Motivation
- Address UI issues reported in issue comment #4133322208 where long-press voice recording conflicts with selectable helper text and the inline NL panel had an extra helper row that broke compact layout.
- Remove redundant helper prompts because inline creation should be compact and the voice/button state already conveys enough information.
- Prevent mobile text-selection on long-press of voice buttons to avoid accidental selection interfering with recording gestures.

### Description
- Removed the second helper/actions row (the `use current example` ghost action and voice hint) from the inline NL form and eliminated the now-unused `applyExample` handler from the inline form in `apps/frontend/src/domains/pr/ui/sections/InlineNLPRForm.vue`.
- Removed the standalone `use current example` helper action and the `applyExample` helper from the full NL form and adjusted `.nl-actions` alignment in `apps/frontend/src/domains/pr/ui/forms/NLPRForm.vue`.
- Added non-selectable styles (`user-select: none`, `-webkit-user-select: none`, `-webkit-touch-callout: none`) to both voice button variants (`.voice-button` and `.voice-action`) to prevent text selection during long-press on touch devices.

### Testing
- Built the frontend with `pnpm --filter @partner-up-dev/frontend build` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c511478d04832caedb5097ee3cfa13)