### PR TITLE
Use native `wx-open-subscribe` element and tidy subscription action styles

### DIFF
--- a/apps/frontend/src/shared/ui/sections/APRNotificationSubscriptions.vue
+++ b/apps/frontend/src/shared/ui/sections/APRNotificationSubscriptions.vue
@@ -28,41 +28,14 @@
         item.openSubscribeTemplateId &&
         !item.actionDisabled
       "
-      class="open-subscribe-proxy"
+      class="native-action-shell"
     >
-      <button
-        :class="[
-          'action-btn',
-          props.outlineProfile === 'surface' ? 'action-btn--surface' : 'action-btn--secondary',
-        ]"
-        type="button"
-      >
-        {{ item.actionLabel }}
-      </button>
-
       <wx-open-subscribe
-        class="open-subscribe-overlay"
+        class="open-subscribe-native"
         :template="item.openSubscribeTemplateId"
         @success="handleOpenSubscribeSuccess(item.key, $event)"
         @error="handleOpenSubscribeError(item.key, $event)"
-      >
-        <script type="text/wxtag-template" slot="style">
-          <style>
-            .open-subscribe-hit-target {
-              width: 100%;
-              height: 100%;
-              border: 0;
-              margin: 0;
-              padding: 0;
-              background: transparent;
-              cursor: pointer;
-            }
-          </style>
-        </script>
-        <script type="text/wxtag-template">
-          <button class="open-subscribe-hit-target"></button>
-        </script>
-      </wx-open-subscribe>
+      />
     </div>
 
     <button
@@ -165,7 +138,7 @@ const handleOpenSubscribeError = async (
   @include mx.pu-surface-card(outline);
   display: flex;
   flex-wrap: wrap;
-  align-items: flex-start;
+  align-items: center;
   justify-content: space-between;
   gap: var(--sys-spacing-sm);
 }
@@ -192,6 +165,7 @@ const handleOpenSubscribeError = async (
 .action-btn {
   @include mx.pu-rect-action(primary, default);
   @include mx.pu-font(label-large);
+  min-width: 7.5rem;
   border: none;
   cursor: pointer;
 }
@@ -218,29 +192,17 @@ const handleOpenSubscribeError = async (
   color: color-mix(in srgb, var(--sys-color-on-surface) 38%, transparent);
 }
 
-.open-subscribe-proxy {
-  position: relative;
+.native-action-shell {
   display: inline-flex;
-  min-height: 2.5rem;
+  align-items: center;
+  justify-content: center;
+  min-height: 3rem;
+  padding: 0 var(--sys-spacing-sm);
+  border-radius: var(--sys-shape-corner-medium);
+  background: var(--sys-color-primary-container);
 }
 
-.open-subscribe-proxy .action-btn {
-  pointer-events: none;
-}
-
-.open-subscribe-overlay {
-  position: absolute;
-  inset: 0;
+.open-subscribe-native {
   display: inline-flex;
-  width: 100%;
-  height: 100%;
-  min-height: 2.5rem;
-}
-
-@media (max-width: 768px) {
-  .subscription-card .action-btn,
-  .subscription-card .open-subscribe-proxy {
-    width: 100%;
-  }
 }
 </style>


### PR DESCRIPTION
### Motivation

- Replace a custom button+overlay hit-target approach with the native `wx-open-subscribe` element to simplify interaction handling and remove injected template scripts.
- Align and refine styles so subscription action buttons have consistent sizing and vertical alignment within the card.

### Description

- Replaced the old `.open-subscribe-proxy` wrapper and embedded `wxtag` templates with a `native-action-shell` wrapper containing a self-closing `<wx-open-subscribe>` with class `open-subscribe-native` and existing success/error handlers. 
- Removed the internal `script` templates and the overlay hit-target button previously used inside `wx-open-subscribe`.
- Updated markup class names and simplified the template branch that renders the native subscribe control.
- Adjusted layout and styles: changed `.subscription-card` alignment to `center`, added `min-width: 7.5rem` to `.action-btn`, and added sizing/appearance rules for `.native-action-shell` and `.open-subscribe-native` to provide a centered, padded, rounded native-action container.

### Testing

- Ran frontend build with `yarn build` which completed successfully.
- Ran unit tests with `yarn test` and the test suite passed.
- Ran linter with `yarn lint` and no lint errors were reported.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c51127fee8832ca0abe5d5aac99e88)