### PR TITLE
fix(frontend): prevent NL voice long-press text selection bleed

### DIFF
--- a/apps/frontend/src/domains/pr/ui/forms/NLPRForm.vue
+++ b/apps/frontend/src/domains/pr/ui/forms/NLPRForm.vue
@@ -18,6 +18,7 @@
             @pointerdown.prevent="handleVoicePressStart"
             @pointerup.prevent="handleVoicePressEnd"
             @pointerleave="handleVoicePressCancel"
+            @pointercancel.prevent="handleVoicePressCancel"
           >
             <span v-if="isVoiceRecording">
               {{ t("nlForm.voiceRecording") }}
@@ -37,7 +38,7 @@
       </div>
     </Field>
 
-    <Button type="submit" :loading="isSubmitting" full-width>
+    <Button type="submit" class="submit-action" :loading="isSubmitting" full-width>
       {{ t("nlForm.submit") }}
     </Button>
 
@@ -177,8 +178,13 @@ const onSubmit = async () => {
   await submitHandler();
 };
 
-const handleVoicePressStart = async () => {
+const handleVoicePressStart = async (event: PointerEvent) => {
   if (!isVoiceSupported.value || isSubmitting.value) return;
+  const target = event.currentTarget;
+  if (target instanceof HTMLElement) {
+    target.setPointerCapture(event.pointerId);
+  }
+
   try {
     await startRecording();
   } catch {
@@ -186,13 +192,21 @@ const handleVoicePressStart = async () => {
   }
 };
 
-const handleVoicePressEnd = async () => {
+const handleVoicePressEnd = async (event: PointerEvent) => {
   if (!isVoiceSupported.value) return;
+  const target = event.currentTarget;
+  if (target instanceof HTMLElement && target.hasPointerCapture(event.pointerId)) {
+    target.releasePointerCapture(event.pointerId);
+  }
   await stopRecording();
 };
 
-const handleVoicePressCancel = async () => {
+const handleVoicePressCancel = async (event: PointerEvent) => {
   if (!isVoiceSupported.value) return;
+  const target = event.currentTarget;
+  if (target instanceof HTMLElement && target.hasPointerCapture(event.pointerId)) {
+    target.releasePointerCapture(event.pointerId);
+  }
   if (isVoiceRecording.value || isVoiceProcessing.value) {
     await stopRecording();
   }
@@ -238,6 +252,7 @@ const handleVoicePressCancel = async () => {
   user-select: none;
   -webkit-user-select: none;
   -webkit-touch-callout: none;
+  touch-action: none;
   cursor: pointer;
   transition:
     background-color 180ms ease,
@@ -269,6 +284,12 @@ const handleVoicePressCancel = async () => {
     opacity: var(--sys-opacity-disabled);
     cursor: not-allowed;
   }
+}
+
+.submit-action {
+  user-select: none;
+  -webkit-user-select: none;
+  -webkit-touch-callout: none;
 }
 
 .error-message {

--- a/apps/frontend/src/domains/pr/ui/sections/InlineNLPRForm.vue
+++ b/apps/frontend/src/domains/pr/ui/sections/InlineNLPRForm.vue
@@ -22,6 +22,7 @@
           @pointerdown.prevent="handleVoicePressStart"
           @pointerup.prevent="handleVoicePressEnd"
           @pointerleave="handleVoicePressCancel"
+          @pointercancel.prevent="handleVoicePressCancel"
         >
           <span
             v-if="isVoiceRecording"
@@ -195,9 +196,14 @@ const onSubmit = async () => {
   await submitHandler();
 };
 
-const handleVoicePressStart = async () => {
+const handleVoicePressStart = async (event: PointerEvent) => {
   if (!isVoiceSupported.value || isSubmitting.value) return;
   if (isVoiceProcessing.value) return;
+  const target = event.currentTarget;
+  if (target instanceof HTMLElement) {
+    target.setPointerCapture(event.pointerId);
+  }
+
   try {
     await startRecording();
   } catch {
@@ -205,13 +211,21 @@ const handleVoicePressStart = async () => {
   }
 };
 
-const handleVoicePressEnd = async () => {
+const handleVoicePressEnd = async (event: PointerEvent) => {
   if (!isVoiceSupported.value) return;
+  const target = event.currentTarget;
+  if (target instanceof HTMLElement && target.hasPointerCapture(event.pointerId)) {
+    target.releasePointerCapture(event.pointerId);
+  }
   await stopRecording();
 };
 
-const handleVoicePressCancel = async () => {
+const handleVoicePressCancel = async (event: PointerEvent) => {
   if (!isVoiceSupported.value) return;
+  const target = event.currentTarget;
+  if (target instanceof HTMLElement && target.hasPointerCapture(event.pointerId)) {
+    target.releasePointerCapture(event.pointerId);
+  }
   if (isVoiceRecording.value || isVoiceProcessing.value) {
     await stopRecording();
   }
@@ -337,6 +351,7 @@ const handleVoicePressCancel = async () => {
   user-select: none;
   -webkit-user-select: none;
   -webkit-touch-callout: none;
+  touch-action: none;
   cursor: pointer;
   transition:
     opacity 180ms ease,


### PR DESCRIPTION
### Motivation
- Long-pressing the NL voice input button could lose interaction ownership and cause the nearby submit label (`解析`) to become text-selected or otherwise receive the pointer, reproducing the issue reported in issue #22 comment 4134223884.

### Description
- Harden voice button interactions in `apps/frontend/src/domains/pr/ui/forms/NLPRForm.vue` by adding `@pointerup`, `@pointerleave`, and `@pointercancel` handlers and changing `handleVoicePress*` signatures to accept `PointerEvent` and use `setPointerCapture`/`releasePointerCapture` to keep the button as the interaction owner during long press.
- Apply the same pointer-capture lifecycle changes to the inline NL form in `apps/frontend/src/domains/pr/ui/sections/InlineNLPRForm.vue` for consistent behavior.
- Add `touch-action: none` to the voice button styles to prevent browser touch gestures from interfering with pointer handling.
- Mark the NL submit action non-selectable by giving the submit `Button` a `submit-action` class and adding `user-select: none` in CSS to avoid accidental text selection of the submit label.

### Testing
- Built the frontend with `pnpm --filter @partner-up-dev/frontend build`, and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c524a3e5dc832c934a5d270cdea105)