### PR TITLE
feat(frontend): switch NL voice input to toggle recording

### DIFF
--- a/apps/frontend/src/domains/pr/ui/forms/NLPRForm.vue
+++ b/apps/frontend/src/domains/pr/ui/forms/NLPRForm.vue
@@ -14,11 +14,9 @@
             type="button"
             class="voice-action"
             :class="{ 'is-recording': isVoiceRecording }"
-            :disabled="isSubmitting"
-            @pointerdown.prevent="handleVoicePressStart"
-            @pointerup.prevent="handleVoicePressEnd"
-            @pointerleave="handleVoicePressCancel"
-            @pointercancel.prevent="handleVoicePressCancel"
+            :disabled="isSubmitting || isVoiceProcessing"
+            :aria-pressed="isVoiceRecording"
+            @click="handleVoiceToggle"
           >
             <span v-if="isVoiceRecording">
               {{ t("nlForm.voiceRecording") }}
@@ -178,37 +176,20 @@ const onSubmit = async () => {
   await submitHandler();
 };
 
-const handleVoicePressStart = async (event: PointerEvent) => {
-  if (!isVoiceSupported.value || isSubmitting.value) return;
-  const target = event.currentTarget;
-  if (target instanceof HTMLElement) {
-    target.setPointerCapture(event.pointerId);
+const handleVoiceToggle = async (): Promise<void> => {
+  if (!isVoiceSupported.value || isSubmitting.value || isVoiceProcessing.value) {
+    return;
+  }
+
+  if (isVoiceRecording.value) {
+    await stopRecording();
+    return;
   }
 
   try {
     await startRecording();
   } catch {
     // Error already captured by hook state.
-  }
-};
-
-const handleVoicePressEnd = async (event: PointerEvent) => {
-  if (!isVoiceSupported.value) return;
-  const target = event.currentTarget;
-  if (target instanceof HTMLElement && target.hasPointerCapture(event.pointerId)) {
-    target.releasePointerCapture(event.pointerId);
-  }
-  await stopRecording();
-};
-
-const handleVoicePressCancel = async (event: PointerEvent) => {
-  if (!isVoiceSupported.value) return;
-  const target = event.currentTarget;
-  if (target instanceof HTMLElement && target.hasPointerCapture(event.pointerId)) {
-    target.releasePointerCapture(event.pointerId);
-  }
-  if (isVoiceRecording.value || isVoiceProcessing.value) {
-    await stopRecording();
   }
 };
 </script>

--- a/apps/frontend/src/domains/pr/ui/sections/InlineNLPRForm.vue
+++ b/apps/frontend/src/domains/pr/ui/sections/InlineNLPRForm.vue
@@ -19,10 +19,7 @@
           :disabled="isSubmitting || isVoiceProcessing"
           :aria-pressed="isVoiceRecording"
           :aria-label="t('nlForm.voiceAction')"
-          @pointerdown.prevent="handleVoicePressStart"
-          @pointerup.prevent="handleVoicePressEnd"
-          @pointerleave="handleVoicePressCancel"
-          @pointercancel.prevent="handleVoicePressCancel"
+          @click="handleVoiceToggle"
         >
           <span
             v-if="isVoiceRecording"
@@ -196,38 +193,20 @@ const onSubmit = async () => {
   await submitHandler();
 };
 
-const handleVoicePressStart = async (event: PointerEvent) => {
-  if (!isVoiceSupported.value || isSubmitting.value) return;
-  if (isVoiceProcessing.value) return;
-  const target = event.currentTarget;
-  if (target instanceof HTMLElement) {
-    target.setPointerCapture(event.pointerId);
+const handleVoiceToggle = async (): Promise<void> => {
+  if (!isVoiceSupported.value || isSubmitting.value || isVoiceProcessing.value) {
+    return;
+  }
+
+  if (isVoiceRecording.value) {
+    await stopRecording();
+    return;
   }
 
   try {
     await startRecording();
   } catch {
     // Error handled by hook state.
-  }
-};
-
-const handleVoicePressEnd = async (event: PointerEvent) => {
-  if (!isVoiceSupported.value) return;
-  const target = event.currentTarget;
-  if (target instanceof HTMLElement && target.hasPointerCapture(event.pointerId)) {
-    target.releasePointerCapture(event.pointerId);
-  }
-  await stopRecording();
-};
-
-const handleVoicePressCancel = async (event: PointerEvent) => {
-  if (!isVoiceSupported.value) return;
-  const target = event.currentTarget;
-  if (target instanceof HTMLElement && target.hasPointerCapture(event.pointerId)) {
-    target.releasePointerCapture(event.pointerId);
-  }
-  if (isVoiceRecording.value || isVoiceProcessing.value) {
-    await stopRecording();
   }
 };
 </script>

--- a/apps/frontend/src/locales/zh-CN.jsonc
+++ b/apps/frontend/src/locales/zh-CN.jsonc
@@ -939,8 +939,8 @@
     "parsing": "正在解析你的请求...",
     "createFailed": "创建失败",
     "useExample": "用当前示例填充",
-    "voiceAction": "按住语音键说话",
-    "voiceRecording": "录音中…松开发送",
+    "voiceAction": "点击开始语音输入",
+    "voiceRecording": "录音中…再次点击结束",
     "voiceProcessing": "正在转写...",
     "voiceWeChatOnly": "语音输入仅在微信内可用",
     "voicePermissionDenied": "无法获取麦克风权限，请允许录音",
@@ -948,7 +948,7 @@
     "voiceStopFailed": "录音结束失败（{message}）",
     "voiceTranslateFailed": "语音转写失败（{message}）",
     "voiceEmptyResult": "没听清，再试一次吧",
-    "voiceHint": "在微信内按住麦克风键说话，松手自动转文字"
+    "voiceHint": "在微信内点击麦克风键开始录音，再次点击转文字"
   },
   "partnerRequestForm": {
     "title": "标题",


### PR DESCRIPTION
### Motivation
- Long-press recording conflicted with text selection and did not provide a reliable long-press experience, so the voice input should use a toggle interaction (click to start, click again to stop) per the issue discussion.

### Description
- Replaced press-and-hold pointer handlers with a click-to-toggle handler `handleVoiceToggle` in `NLPRForm.vue` to start/stop recording and to avoid pointer capture/selection conflicts.
- Applied the same toggle behavior to the inline form in `InlineNLPRForm.vue` for consistent UX and simplified event handling.
- Added `:aria-pressed="isVoiceRecording"` and disabled the voice control while submitting or processing via `:disabled="isSubmitting || isVoiceProcessing"` to improve accessibility and race handling.
- Updated Chinese copy in `src/locales/zh-CN.jsonc` to reflect the new toggle interaction phraseology.

### Testing
- Ran the frontend build with `pnpm --filter @partner-up-dev/frontend build`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c52aac0d3c832cb917af4b862807dc)