### PR TITLE
fix(frontend): keep inline voice icon visible in recording state

### DIFF
--- a/apps/frontend/src/domains/pr/ui/sections/InlineNLPRForm.vue
+++ b/apps/frontend/src/domains/pr/ui/sections/InlineNLPRForm.vue
@@ -15,6 +15,7 @@
         <button
           v-if="isVoiceSupported"
           class="voice-button"
+          :class="{ 'is-recording': isVoiceRecording }"
           type="button"
           :disabled="isSubmitting || isVoiceProcessing"
           :aria-pressed="isVoiceRecording"
@@ -344,6 +345,13 @@ const handleVoiceToggle = async (): Promise<void> => {
 
   &:active:not(:disabled) {
     transform: scale(0.98);
+  }
+
+  &.is-recording {
+    border-style: solid;
+    border-color: var(--sys-color-primary);
+    background: var(--sys-color-primary);
+    color: var(--sys-color-on-primary);
   }
 
   &:disabled {


### PR DESCRIPTION
### Motivation
- Fix a visual regression reported in issue #22 (comment id 4134566330) where the Inline NL form voice button icon became invisible in the active/toggled recording state because the icon color matched the active background while preserving the toggle behavior.

### Description
- Add an explicit recording class binding to the inline voice button (`:class="{ 'is-recording': isVoiceRecording }"`) and introduce `.voice-button.is-recording` styles in `apps/frontend/src/domains/pr/ui/sections/InlineNLPRForm.vue` to set `border-style`, `border-color: var(--sys-color-primary)`, `background: var(--sys-color-primary)`, and `color: var(--sys-color-on-primary)` so the icon/text remain high-contrast when recording.

### Testing
- Ran `pnpm --filter @partner-up-dev/frontend build` (includes `vue-tsc` and `vite build`), and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c52ed29140832c9774fded89389ad7)