### PR TITLE
feat(shared-ui): add reusable primitives

### DIFF
--- a/apps/frontend/AGENTS.md
+++ b/apps/frontend/AGENTS.md
@@ -16,6 +16,7 @@
 - Styling governance: use direct `sys` tokens first (Material3 style); add `dcs` only for real governed outputs; add recipes only for governed logic or stable shared treatments.
 - Make use of SCSS features.
 - Page layout reuse: Prefer `src/shared/ui/layout/PageScaffold.vue`, `PageScaffoldFlow.vue`, `PageScaffoldCentered.vue`, and `DesktopPageScaffold.vue` for route pages; do not duplicate root safe-area container styles in page files.
+- Shared UI reuse: before adding page-local shells or feedback widgets, check `src/shared/ui/AGENTS.md` and prefer existing primitives such as `SurfaceCard`, `FormField`, `Button`, `InfoRow`, `Chip`, `ChipGroup`, `InlineNotice`, `EmptyState`, `ConfirmDialog`, and `Avatar` when the fit is real.
 - Feature composition boundary: extract reusable feature UI + business logic into dedicated feature components (for example, `APRNotificationSubscriptions`) instead of leaving logic in page files.
 - Container vs feature split: keep container components (for example, `WeChatNotificationSubscriptionsCard`) presentational-only; they should provide layout/shell and should not own feature side effects.
 - Usage-site assembly: pages (for example, `AnchorPRPage`) should assemble container + feature components, and only own page context such as visibility, section placement, and page-level error aggregation.

--- a/apps/frontend/src/AGENTS.components.md
+++ b/apps/frontend/src/AGENTS.components.md
@@ -81,6 +81,15 @@ Prohibited:
 
 ## Components
 
+- `shared/ui/actions/Button.vue`: Shared button primitive. Prefer it over page-local button classes; use `appearance="pill"` for compact CTA clusters and `appearance="rect"` for dialogs or block actions. Keep `tone` choices narrow (`primary`, `outline`, `secondary`, `surface`, `danger`, `ghost`).
+- `shared/ui/containers/SurfaceCard.vue`: Standard card shell for reusable section, inset, and outline surfaces. Use it instead of re-declaring `pu-surface-card(...)` in pages when the wrapper itself is a reusable primitive.
+- `shared/ui/forms/FormField.vue`: Label + control + hint/error wrapper for plain form rows. It does not own the input shell; pair it with native controls or existing form primitives that already style the control.
+- `shared/ui/display/InfoRow.vue`: Generic label/value row with inline or stacked layout. Use it for neutral metadata presentation, not domain-specific timeline or status logic.
+- `shared/ui/display/Chip.vue` and `shared/ui/display/ChipGroup.vue`: Neutral tokenized chips for tags, lightweight roster labels, and compact metadata groups. Do not move domain semantics like PR status into these when a domain badge already exists.
+- `shared/ui/feedback/InlineNotice.vue`: Inline success/info/warning/error banner. Prefer it over page-local feedback blocks when the message is simple and does not need toast behavior.
+- `shared/ui/feedback/EmptyState.vue`: Empty or not-found shell with title, description, icon, and optional actions slot.
+- `shared/ui/overlay/ConfirmDialog.vue`: Standard confirm/cancel dialog built on `Modal` and `Button`. Use it for straightforward confirmation flows instead of rebuilding modal actions per page.
+- `shared/ui/identity/Avatar.vue`: Shared avatar with image and fallback initial. Prefer it over per-page avatar fallback markup when the need is generic identity display.
 - `shared/ui/overlay/Modal.vue`: Generic modal primitive. Add scroll locking with `useBodyScrollLock(computed(() => open.value))` in the parent when needed.
 - `domains/pr/ui/forms/DateTimeRangePicker.vue`: Standalone time-window picker for start/end date-time.
 - `domains/pr/ui/forms/PRForm.vue`: Structured PR create/edit form using `src/lib/validation`.

--- a/apps/frontend/src/pages/AnchorPRPage.vue
+++ b/apps/frontend/src/pages/AnchorPRPage.vue
@@ -35,14 +35,13 @@
         </template>
       </PageHeader>
 
-      <section class="section-card event-fit-card">
+      <SurfaceCard as="section" class="section-card event-fit-card">
         <h2 class="section-title">活动信息</h2>
-        <div class="fit-row">
-          <span class="fit-label">{{ t("prCard.location") }}</span>
-          <span class="fit-value">{{
+        <InfoRow :label="t('prCard.location')">
+          {{
             prDetail.core.location ?? t("prPage.partnerSection.notSet")
-          }}</span>
-        </div>
+          }}
+        </InfoRow>
         <button
           v-if="locationGallery.length > 0"
           class="location-gallery-link"
@@ -51,43 +50,43 @@
         >
           {{ t("prCard.viewLocationImages") }}
         </button>
-        <div class="fit-row">
-          <span class="fit-label">{{ t("prCard.time") }}</span>
-          <span class="fit-value">{{ localizedTimeText }}</span>
-        </div>
-        <div class="fit-row fit-row--stack">
-          <span class="fit-label">{{ t("prCard.preferences") }}</span>
-          <div class="fit-tags">
-            <span
+        <InfoRow :label="t('prCard.time')">
+          {{ localizedTimeText }}
+        </InfoRow>
+        <InfoRow :label="t('prCard.preferences')" layout="stack" align="start">
+          <ChipGroup>
+            <Chip
               v-for="item in prDetail.core.preferences"
               :key="item"
-              class="fit-tag"
             >
               {{ item }}
-            </span>
-            <span
-              v-if="prDetail.core.preferences.length === 0"
-              class="fit-empty"
-            >
-              {{ t("prPage.partnerSection.notSet") }}
-            </span>
-          </div>
-        </div>
-        <div class="fit-row fit-row--stack">
-          <span class="fit-label">参与概览</span>
+            </Chip>
+          </ChipGroup>
+          <span
+            v-if="prDetail.core.preferences.length === 0"
+            class="fit-empty"
+          >
+            {{ t("prPage.partnerSection.notSet") }}
+          </span>
+        </InfoRow>
+        <InfoRow label="参与概览" layout="stack" align="start">
           <p class="fit-overview">{{ participantOverviewText }}</p>
-          <div class="roster-chips">
-            <span
+          <ChipGroup>
+            <Chip
               v-for="item in rosterPreview"
               :key="item.partnerId"
-              class="roster-chip"
             >
               {{ item.displayName }}
+            </Chip>
+            <span
+              v-if="hasMoreRoster"
+              class="roster-chip-overflow"
+            >
+              ...
             </span>
-            <span v-if="hasMoreRoster" class="roster-chip">...</span>
-          </div>
-        </div>
-      </section>
+          </ChipGroup>
+        </InfoRow>
+      </SurfaceCard>
 
       <section v-if="releaseNoticeText" class="section-card released-notice">
         <p class="released-notice__text">{{ releaseNoticeText }}</p>
@@ -330,34 +329,20 @@
         <p v-if="joinFlowError" class="action-error">{{ joinFlowError }}</p>
       </Modal>
 
-      <Modal
+      <ConfirmDialog
         :open="showExitConfirmModal"
         title="确认退出"
+        message="退出后你的参与名额会被释放，确认继续？"
+        :confirm-label="
+          sharedActions.exitPending.value
+            ? t('prPage.exiting')
+            : t('common.confirm')
+        "
+        confirm-tone="danger"
+        :loading="sharedActions.exitPending.value"
         @close="showExitConfirmModal = false"
-      >
-        <p class="modal-text">退出后你的参与名额会被释放，确认继续？</p>
-        <div class="modal-actions">
-          <button
-            class="action-btn action-btn--surface"
-            type="button"
-            @click="showExitConfirmModal = false"
-          >
-            {{ t("common.cancel") }}
-          </button>
-          <button
-            class="action-btn action-btn--danger"
-            type="button"
-            :disabled="sharedActions.exitPending.value"
-            @click="confirmExit"
-          >
-            {{
-              sharedActions.exitPending.value
-                ? t("prPage.exiting")
-                : t("common.confirm")
-            }}
-          </button>
-        </div>
-      </Modal>
+        @confirm="confirmExit"
+      />
 
       <Modal
         :open="attendanceActions.showCheckInFollowup.value"
@@ -409,7 +394,12 @@ import type { PRId } from "@partner-up-dev/backend";
 import LoadingIndicator from "@/shared/ui/feedback/LoadingIndicator.vue";
 import ErrorToast from "@/shared/ui/feedback/ErrorToast.vue";
 import Modal from "@/shared/ui/overlay/Modal.vue";
+import ConfirmDialog from "@/shared/ui/overlay/ConfirmDialog.vue";
 import BottomDrawer from "@/shared/ui/overlay/BottomDrawer.vue";
+import SurfaceCard from "@/shared/ui/containers/SurfaceCard.vue";
+import InfoRow from "@/shared/ui/display/InfoRow.vue";
+import Chip from "@/shared/ui/display/Chip.vue";
+import ChipGroup from "@/shared/ui/display/ChipGroup.vue";
 import PRLocationGalleryModal from "@/domains/pr/ui/modals/PRLocationGalleryModal.vue";
 import EditPRContentModal from "@/domains/pr/ui/modals/EditPRContentModal.vue";
 import UpdatePRStatusModal from "@/domains/pr/ui/modals/UpdatePRStatusModal.vue";
@@ -1233,45 +1223,6 @@ const reimbursementReasonText = (
   color: var(--sys-color-on-surface-variant);
 }
 
-.fit-row {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  gap: var(--sys-spacing-sm);
-}
-
-.fit-row--stack {
-  flex-direction: column;
-  align-items: flex-start;
-}
-
-.fit-label {
-  @include mx.pu-font(label-large);
-  color: var(--sys-color-on-surface-variant);
-}
-
-.fit-value {
-  @include mx.pu-font(body-medium);
-  color: var(--sys-color-on-surface);
-  text-align: right;
-}
-
-.fit-tags,
-.roster-chips {
-  display: flex;
-  flex-wrap: wrap;
-  gap: var(--sys-spacing-xs);
-}
-
-.fit-tag,
-.roster-chip {
-  @include mx.pu-font(label-medium);
-  padding: var(--sys-spacing-xs) var(--sys-spacing-sm);
-  border-radius: 999px;
-  background: var(--sys-color-secondary-container);
-  color: var(--sys-color-on-secondary-container);
-}
-
 .fit-empty {
   @include mx.pu-font(body-small);
   color: var(--sys-color-on-surface-variant);
@@ -1280,6 +1231,18 @@ const reimbursementReasonText = (
 .fit-overview {
   margin: 0;
   @include mx.pu-font(body-medium);
+}
+
+.roster-chip-overflow {
+  @include mx.pu-font(label-medium);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: var(--sys-size-medium);
+  padding: var(--sys-spacing-xs) var(--sys-spacing-sm);
+  border-radius: 999px;
+  background: var(--sys-color-secondary-container);
+  color: var(--sys-color-on-secondary-container);
 }
 
 .booking-support-entry-card__header {
@@ -1420,15 +1383,6 @@ const reimbursementReasonText = (
 }
 
 @media (max-width: 879px) {
-  .fit-row {
-    flex-direction: column;
-    align-items: flex-start;
-  }
-
-  .fit-value {
-    text-align: left;
-  }
-
   .header-quick-actions {
     flex-wrap: wrap;
     justify-content: flex-end;

--- a/apps/frontend/src/pages/MePage.vue
+++ b/apps/frontend/src/pages/MePage.vue
@@ -8,16 +8,11 @@
     </template>
 
     <div class="page-main">
-      <div
+      <InlineNotice
         v-if="bindFeedbackMessage"
-        class="feedback-banner"
-        :class="{
-          'feedback-banner--success': bindFeedbackCode === 'success',
-          'feedback-banner--error': bindFeedbackCode !== 'success',
-        }"
-      >
-        <p>{{ bindFeedbackMessage }}</p>
-      </div>
+        :tone="bindFeedbackCode === 'success' ? 'success' : 'error'"
+        :message="bindFeedbackMessage"
+      />
 
       <ErrorToast v-if="errorMessage" :message="errorMessage" persistent />
 
@@ -28,7 +23,7 @@
         :message="t('mePage.loading')"
       />
 
-      <section class="surface-card">
+      <SurfaceCard gap="md">
         <div class="section-header">
           <div>
             <h2>{{ t("mePage.profile.title") }}</h2>
@@ -47,62 +42,55 @@
         </div>
 
         <div class="profile-panel">
-          <div class="avatar-shell">
-            <img
-              v-if="avatarUrl"
-              :src="avatarUrl"
-              :alt="t('mePage.profile.avatarAlt')"
-              class="avatar-image"
-            />
-            <div v-else class="avatar-fallback">
-              <span>{{ avatarFallbackText }}</span>
-            </div>
-          </div>
+          <Avatar
+            :src="avatarUrl"
+            :alt="t('mePage.profile.avatarAlt')"
+            :name="currentUser?.nickname ?? null"
+            :fallback="avatarFallbackText"
+            size="xl"
+          />
 
           <div class="profile-form">
-            <label class="field">
-              <span class="field__label">{{
-                t("mePage.profile.nicknameLabel")
-              }}</span>
+            <FormField
+              :label="t('mePage.profile.nicknameLabel')"
+              for-id="me-profile-nickname"
+            >
               <input
+                id="me-profile-nickname"
                 v-model="nicknameDraft"
-                class="field__input"
+                class="text-input"
                 type="text"
                 :placeholder="t('mePage.profile.nicknamePlaceholder')"
                 :disabled="!canEditProfile"
                 maxlength="40"
                 @keydown.enter.prevent="handleSaveNickname"
               />
-            </label>
+            </FormField>
 
             <div class="profile-actions">
-              <button
-                class="primary-button"
+              <Button
+                appearance="pill"
+                size="sm"
                 type="button"
                 :disabled="!canSaveNickname"
+                :loading="updateProfileMutation.isPending.value"
                 @click="handleSaveNickname"
               >
-                {{
-                  updateProfileMutation.isPending.value
-                    ? t("mePage.profile.savingNickname")
-                    : t("mePage.profile.saveNickname")
-                }}
-              </button>
+                {{ t("mePage.profile.saveNickname") }}
+              </Button>
 
-              <button
-                class="secondary-button"
+              <Button
+                appearance="pill"
+                tone="outline"
+                size="sm"
                 type="button"
-                :disabled="
-                  !canEditProfile || updateAvatarMutation.isPending.value
-                "
+                :disabled="!canEditProfile || updateAvatarMutation.isPending.value"
+                :loading="updateAvatarMutation.isPending.value"
                 @click="handlePickAvatar"
               >
-                {{
-                  updateAvatarMutation.isPending.value
-                    ? t("mePage.profile.uploadingAvatar")
-                    : t("mePage.profile.changeAvatar")
-                }}
-              </button>
+                {{ t("mePage.profile.changeAvatar") }}
+              </Button>
+
               <input
                 ref="avatarInputRef"
                 class="sr-only"
@@ -113,10 +101,10 @@
             </div>
           </div>
         </div>
-      </section>
+      </SurfaceCard>
 
       <template v-if="!userSessionStore.isAuthenticated">
-        <section class="surface-card">
+        <SurfaceCard gap="md">
           <div class="section-header">
             <div>
               <h2>{{ t("mePage.wechatLogin.title") }}</h2>
@@ -124,22 +112,20 @@
             </div>
           </div>
 
-          <button
+          <Button
             v-if="isWeChatEnv"
-            class="primary-button"
+            appearance="pill"
+            size="sm"
             type="button"
             :disabled="wechatLoginPending"
+            :loading="wechatLoginPending"
             @click="handleStartWeChatLogin"
           >
-            {{
-              wechatLoginPending
-                ? t("mePage.wechatLogin.pending")
-                : t("mePage.wechatLogin.action")
-            }}
-          </button>
-        </section>
+            {{ t("mePage.wechatLogin.action") }}
+          </Button>
+        </SurfaceCard>
 
-        <section class="surface-card">
+        <SurfaceCard gap="md">
           <div class="section-header">
             <div>
               <h2>{{ t("mePage.pinLogin.title") }}</h2>
@@ -148,27 +134,32 @@
           </div>
 
           <div class="pin-login-fields">
-            <label class="field">
-              <span class="field__label">{{
-                t("mePage.pinLogin.userIdLabel")
-              }}</span>
+            <FormField
+              :label="t('mePage.pinLogin.userIdLabel')"
+              for-id="me-login-user-id"
+            >
               <input
+                id="me-login-user-id"
                 v-model="pinLoginDraft.userId"
-                class="field__input"
+                class="text-input"
                 type="text"
                 :placeholder="t('mePage.pinLogin.userIdPlaceholder')"
                 autocomplete="username"
                 @keydown.enter.prevent="handlePinLogin"
               />
-            </label>
+            </FormField>
 
-            <label class="field">
-              <span class="field__label">{{
-                t("mePage.pinLogin.pinLabel")
-              }}</span>
+            <FormField
+              :label="t('mePage.pinLogin.pinLabel')"
+              for-id="me-login-user-pin"
+              :hint="
+                showPinFormatHint ? t('mePage.pinLogin.pinFormatHint') : null
+              "
+            >
               <input
+                id="me-login-user-pin"
                 v-model="pinLoginDraft.userPin"
-                class="field__input"
+                class="text-input"
                 type="password"
                 inputmode="numeric"
                 pattern="[0-9]*"
@@ -177,43 +168,37 @@
                 autocomplete="one-time-code"
                 @keydown.enter.prevent="handlePinLogin"
               />
-              <p v-if="showPinFormatHint" class="field__hint">
-                {{ t("mePage.pinLogin.pinFormatHint") }}
-              </p>
-            </label>
+            </FormField>
           </div>
 
           <div class="profile-actions">
-            <button
-              class="primary-button"
+            <Button
+              appearance="pill"
+              size="sm"
               type="button"
               :disabled="!canSubmitPinLogin"
+              :loading="loginWithPinMutation.isPending.value"
               @click="handlePinLogin"
             >
-              {{
-                loginWithPinMutation.isPending.value
-                  ? t("mePage.pinLogin.pending")
-                  : t("mePage.pinLogin.action")
-              }}
-            </button>
-            <button
-              class="secondary-button"
+              {{ t("mePage.pinLogin.action") }}
+            </Button>
+            <Button
+              appearance="pill"
+              tone="outline"
+              size="sm"
               type="button"
               :disabled="registerLocalAccountMutation.isPending.value"
+              :loading="registerLocalAccountMutation.isPending.value"
               @click="handleRegisterLocalAccount"
             >
-              {{
-                registerLocalAccountMutation.isPending.value
-                  ? t("mePage.register.pending")
-                  : t("mePage.register.action")
-              }}
-            </button>
+              {{ t("mePage.register.action") }}
+            </Button>
           </div>
-        </section>
+        </SurfaceCard>
       </template>
 
       <template v-else>
-        <section class="surface-card">
+        <SurfaceCard gap="md">
           <div class="section-header">
             <div>
               <h2>{{ t("mePage.wechat.title") }}</h2>
@@ -221,10 +206,12 @@
             </div>
           </div>
 
-          <button
-            class="primary-button"
+          <Button
+            appearance="pill"
+            size="sm"
             type="button"
             :disabled="bindActionDisabled"
+            :loading="startWeChatBindMutation.isPending.value"
             @click="handleStartWeChatBind"
           >
             {{
@@ -234,8 +221,8 @@
                   ? t("mePage.wechat.boundAction")
                   : t("mePage.wechat.bindAction")
             }}
-          </button>
-        </section>
+          </Button>
+        </SurfaceCard>
 
         <WeChatNotificationSubscriptionsCard
           :title="t('mePage.reminder.title')"
@@ -246,7 +233,7 @@
           />
         </WeChatNotificationSubscriptionsCard>
 
-        <section class="surface-card">
+        <SurfaceCard gap="md">
           <div class="section-header">
             <div>
               <h2>{{ t("mePage.credentials.title") }}</h2>
@@ -262,8 +249,10 @@
                 }}</span>
                 <code class="credential-value">{{ storedUserIdLabel }}</code>
               </div>
-              <button
-                class="secondary-button"
+              <Button
+                appearance="pill"
+                tone="outline"
+                size="sm"
                 type="button"
                 :disabled="!storedUserId"
                 @click="handleCopyCredential('userId', storedUserId)"
@@ -271,7 +260,7 @@
                 {{
                   copiedField === "userId" ? t("common.copied") : t("common.copy")
                 }}
-              </button>
+              </Button>
             </div>
 
             <div class="credential-item">
@@ -282,8 +271,10 @@
                 <code class="credential-value">{{ displayedUserPin }}</code>
               </div>
               <div class="credential-actions">
-                <button
-                  class="secondary-button"
+                <Button
+                  appearance="pill"
+                  tone="outline"
+                  size="sm"
                   type="button"
                   :disabled="!storedUserPin"
                   @click="pinVisible = !pinVisible"
@@ -293,9 +284,11 @@
                       ? t("mePage.credentials.hidePin")
                       : t("mePage.credentials.showPin")
                   }}
-                </button>
-                <button
-                  class="secondary-button"
+                </Button>
+                <Button
+                  appearance="pill"
+                  tone="outline"
+                  size="sm"
                   type="button"
                   :disabled="!storedUserPin"
                   @click="handleCopyCredential('userPin', storedUserPin)"
@@ -305,11 +298,11 @@
                       ? t("common.copied")
                       : t("common.copy")
                   }}
-                </button>
+                </Button>
               </div>
             </div>
           </div>
-        </section>
+        </SurfaceCard>
 
         <RouterLink class="history-link" :to="{ name: 'pr-mine' }">
           <div class="history-link__copy">
@@ -339,9 +332,14 @@ import { RouterLink, useRoute } from "vue-router";
 import { useI18n } from "vue-i18n";
 import LoadingIndicator from "@/shared/ui/feedback/LoadingIndicator.vue";
 import ErrorToast from "@/shared/ui/feedback/ErrorToast.vue";
+import InlineNotice from "@/shared/ui/feedback/InlineNotice.vue";
 import ContactSupportFooter from "@/domains/support/ui/sections/ContactSupportFooter.vue";
 import PageHeader from "@/shared/ui/navigation/PageHeader.vue";
 import PageScaffoldFlow from "@/shared/ui/layout/PageScaffoldFlow.vue";
+import SurfaceCard from "@/shared/ui/containers/SurfaceCard.vue";
+import FormField from "@/shared/ui/forms/FormField.vue";
+import Avatar from "@/shared/ui/identity/Avatar.vue";
+import Button from "@/shared/ui/actions/Button.vue";
 import WeChatNotificationSubscriptionsCard from "@/shared/ui/sections/WeChatNotificationSubscriptionsCard.vue";
 import APRNotificationSubscriptions from "@/shared/ui/sections/APRNotificationSubscriptions.vue";
 import { useUserSessionStore } from "@/shared/auth/useUserSessionStore";
@@ -573,7 +571,6 @@ const handleCopyCredential = async (
       error instanceof Error ? error.message : t("common.copyFailed");
   }
 };
-
 </script>
 
 <style scoped lang="scss">
@@ -583,35 +580,8 @@ const handleCopyCredential = async (
   gap: var(--sys-spacing-lg);
 }
 
-.surface-card,
 .history-link {
   @include mx.pu-surface-card(section);
-}
-
-.surface-card {
-  display: flex;
-  flex-direction: column;
-  gap: var(--sys-spacing-med);
-}
-
-.feedback-banner {
-  border-radius: var(--sys-radius-md);
-  padding: var(--sys-spacing-sm) var(--sys-spacing-med);
-
-  p {
-    margin: 0;
-    @include mx.pu-font(body-medium);
-  }
-}
-
-.feedback-banner--success {
-  background: color-mix(in srgb, var(--sys-color-primary) 14%, white);
-  color: var(--sys-color-on-surface);
-}
-
-.feedback-banner--error {
-  background: var(--sys-color-error-container);
-  color: var(--sys-color-on-error-container);
 }
 
 .section-header {
@@ -653,33 +623,7 @@ const handleCopyCredential = async (
   align-items: center;
 }
 
-.avatar-shell,
-.avatar-image,
-.avatar-fallback {
-  width: 5.5rem;
-  height: 5.5rem;
-  border-radius: 999px;
-}
-
-.avatar-image {
-  object-fit: cover;
-  display: block;
-}
-
-.avatar-fallback {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background: var(--sys-color-primary-container);
-  color: var(--sys-color-on-primary-container);
-
-  span {
-    @include mx.pu-font(headline-small);
-  }
-}
-
 .profile-form,
-.field,
 .pin-login-fields {
   display: flex;
   flex-direction: column;
@@ -690,19 +634,8 @@ const handleCopyCredential = async (
   gap: var(--sys-spacing-med);
 }
 
-.field__label {
-  @include mx.pu-font(label-large);
-  color: var(--sys-color-on-surface-variant);
-}
-
-.field__input {
+.text-input {
   @include mx.pu-field-shell;
-}
-
-.field__hint {
-  margin: 0;
-  @include mx.pu-font(body-small);
-  color: var(--sys-color-on-surface-variant);
 }
 
 .profile-actions,
@@ -710,27 +643,6 @@ const handleCopyCredential = async (
   display: flex;
   flex-wrap: wrap;
   gap: var(--sys-spacing-sm);
-}
-
-.primary-button,
-.secondary-button {
-  @include mx.pu-font(label-large);
-  border: none;
-  cursor: pointer;
-}
-
-.primary-button {
-  @include mx.pu-pill-action(solid-primary, small);
-}
-
-.secondary-button {
-  @include mx.pu-pill-action(outline-transparent, small);
-}
-
-.primary-button:disabled,
-.secondary-button:disabled {
-  cursor: default;
-  opacity: 0.58;
 }
 
 .credential-list {

--- a/apps/frontend/src/pages/UserProfilePage.vue
+++ b/apps/frontend/src/pages/UserProfilePage.vue
@@ -13,10 +13,13 @@
       :message="t('userProfilePage.loading')"
     />
 
-    <section v-else-if="isNotFound" class="surface-card">
-      <h2 class="section-title">{{ t("userProfilePage.notFoundTitle") }}</h2>
-      <p class="section-copy">{{ t("userProfilePage.notFoundDescription") }}</p>
-    </section>
+    <EmptyState
+      v-else-if="isNotFound"
+      :title="t('userProfilePage.notFoundTitle')"
+      :description="t('userProfilePage.notFoundDescription')"
+      icon="i-mdi-account-off-outline"
+      tone="outline"
+    />
 
     <ErrorToast
       v-else-if="errorMessage"
@@ -24,7 +27,7 @@
       persistent
     />
 
-    <section v-else-if="profile" class="surface-card">
+    <SurfaceCard v-else-if="profile" gap="md">
       <div
         v-if="profile.isCurrentLocalUser"
         class="profile-actions"
@@ -35,22 +38,21 @@
       </div>
 
       <div class="profile-row">
-        <img
-          v-if="profile.avatarUrl"
+        <Avatar
           :src="profile.avatarUrl"
           :alt="t('userProfilePage.avatarAlt', { name: displayName })"
-          class="avatar-image"
+          :name="displayName"
+          :fallback="avatarFallbackText"
+          size="lg"
+          bordered
         />
-        <div v-else class="avatar-fallback" aria-hidden="true">
-          <span>{{ avatarFallbackText }}</span>
-        </div>
 
         <div class="profile-copy">
           <span class="nickname-label">{{ t("userProfilePage.nicknameLabel") }}</span>
           <strong class="nickname-value">{{ displayName }}</strong>
         </div>
       </div>
-    </section>
+    </SurfaceCard>
 
     <template #footer>
       <ContactSupportFooter />
@@ -67,6 +69,9 @@ import PageScaffoldFlow from "@/shared/ui/layout/PageScaffoldFlow.vue";
 import PageHeader from "@/shared/ui/navigation/PageHeader.vue";
 import LoadingIndicator from "@/shared/ui/feedback/LoadingIndicator.vue";
 import ErrorToast from "@/shared/ui/feedback/ErrorToast.vue";
+import EmptyState from "@/shared/ui/feedback/EmptyState.vue";
+import SurfaceCard from "@/shared/ui/containers/SurfaceCard.vue";
+import Avatar from "@/shared/ui/identity/Avatar.vue";
 import ContactSupportFooter from "@/domains/support/ui/sections/ContactSupportFooter.vue";
 import {
   anchorPRDetailPath,
@@ -96,7 +101,11 @@ const scenario = computed<PRPartnerProfileScenario | null>(() => {
 const prId = computed(() => parsePositiveInt(route.params.id));
 const partnerId = computed(() => parsePositiveInt(route.params.partnerId));
 
-const { data, isLoading, error } = usePRPartnerProfile(scenario, prId, partnerId);
+const { data, isLoading, error } = usePRPartnerProfile(
+  scenario,
+  prId,
+  partnerId,
+);
 const profile = computed(() => data.value ?? null);
 
 const subtitle = computed(() => {
@@ -151,30 +160,6 @@ const backFallbackTo = computed(() => {
 </script>
 
 <style scoped lang="scss">
-.surface-card {
-  @include mx.pu-surface-card(section);
-}
-
-.surface-card {
-  display: flex;
-  flex-direction: column;
-  gap: var(--sys-spacing-sm);
-}
-
-.section-title,
-.section-copy {
-  margin: 0;
-}
-
-.section-title {
-  @include mx.pu-font(title-medium);
-}
-
-.section-copy {
-  @include mx.pu-font(body-medium);
-  color: var(--sys-color-on-surface-variant);
-}
-
 .profile-actions {
   display: flex;
   justify-content: flex-end;
@@ -194,32 +179,6 @@ const backFallbackTo = computed(() => {
   display: flex;
   align-items: center;
   gap: var(--sys-spacing-med);
-}
-
-.avatar-image,
-.avatar-fallback {
-  width: 4.75rem;
-  height: 4.75rem;
-  border-radius: 999px;
-  flex-shrink: 0;
-}
-
-.avatar-image {
-  display: block;
-  object-fit: cover;
-}
-
-.avatar-fallback {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background: var(--sys-color-primary-container);
-  color: var(--sys-color-on-primary-container);
-  border: 1px solid var(--sys-color-outline-variant);
-
-  span {
-    @include mx.pu-font(title-large);
-  }
 }
 
 .profile-copy {

--- a/apps/frontend/src/shared/ui/AGENTS.md
+++ b/apps/frontend/src/shared/ui/AGENTS.md
@@ -1,1 +1,29 @@
 `src/shared/ui` owns true cross-domain UI primitives only.
+
+Use `shared/ui` when all of these are true:
+
+- the component is reusable across multiple screens or domains
+- the API is stable and intentionally narrow
+- the component does not encode domain-specific copy or workflow rules
+- the component can be documented as a primitive instead of a usage pattern
+
+Do not move a component into `shared/ui` just because two pages happen to look similar once. Repetition alone is not enough if the semantics are domain-owned.
+
+## Preferred Primitives
+
+- `actions/Button.vue`: shared button primitive for pill and rect actions; prefer it over page-local button classes.
+- `containers/SurfaceCard.vue`: shared card shell for section, outline, and inset treatments.
+- `forms/FormField.vue`: label + control + hint/error wrapper for plain field rows.
+- `display/InfoRow.vue`: neutral label/value layout for metadata.
+- `display/Chip.vue` and `display/ChipGroup.vue`: lightweight shared tag/group primitives.
+- `feedback/InlineNotice.vue`: inline notice banner for page-level or section-level feedback.
+- `feedback/EmptyState.vue`: empty/not-found shell with optional icon and actions.
+- `overlay/ConfirmDialog.vue`: standard confirm/cancel dialog for simple destructive or blocking confirmations.
+- `identity/Avatar.vue`: generic avatar with image/fallback behavior.
+
+## Reuse Rules
+
+- Prefer composing these primitives in pages and domain sections before creating new page-local shells.
+- If a component needs backend-derived policy logic, workflow branching, or domain vocabulary, keep it in the owning domain and compose shared primitives inside it.
+- If a primitive variant is needed in a third distinct place, extend the shared primitive API instead of cloning the component locally.
+- When extending a primitive API, update `src/AGENTS.components.md` in the same change so the new contract stays discoverable.

--- a/apps/frontend/src/shared/ui/actions/Button.vue
+++ b/apps/frontend/src/shared/ui/actions/Button.vue
@@ -2,37 +2,90 @@
   <button
     class="ui-button"
     :class="[
-      `ui-button--${variant}`,
-      { 'ui-button--full-width': fullWidth, 'is-loading': loading },
+      `ui-button--appearance-${props.appearance}`,
+      `ui-button--tone-${resolvedTone}`,
+      `ui-button--size-${props.size}`,
+      {
+        'ui-button--block': isBlock,
+        'ui-button--full-width': isBlock,
+        'is-loading': props.loading,
+      },
     ]"
-    :type="type"
-    :disabled="disabled || loading"
+    :type="props.type"
+    :disabled="props.disabled || props.loading"
     @click="$emit('click', $event)"
   >
-    <span v-if="loading" class="ui-button__spinner" aria-hidden="true"></span>
+    <span
+      v-if="$slots.leading && !props.loading"
+      class="ui-button__leading"
+      aria-hidden="true"
+    >
+      <slot name="leading" />
+    </span>
+    <span
+      v-if="props.loading"
+      class="ui-button__spinner"
+      aria-hidden="true"
+    ></span>
     <span class="ui-button__content">
       <slot />
+    </span>
+    <span
+      v-if="$slots.trailing && !props.loading"
+      class="ui-button__trailing"
+      aria-hidden="true"
+    >
+      <slot name="trailing" />
     </span>
   </button>
 </template>
 
 <script setup lang="ts">
-withDefaults(
+import { computed } from "vue";
+
+type ButtonAppearance = "rect" | "pill";
+type ButtonTone =
+  | "primary"
+  | "secondary"
+  | "outline"
+  | "surface"
+  | "danger"
+  | "ghost";
+type ButtonSize = "sm" | "md" | "lg";
+
+const props = withDefaults(
   defineProps<{
     type?: "button" | "submit" | "reset";
     variant?: "primary" | "secondary";
+    appearance?: ButtonAppearance;
+    tone?: ButtonTone;
+    size?: ButtonSize;
     loading?: boolean;
     disabled?: boolean;
+    block?: boolean;
     fullWidth?: boolean;
   }>(),
   {
     type: "button",
-    variant: "primary",
+    variant: undefined,
+    appearance: "rect",
+    tone: undefined,
+    size: "md",
     loading: false,
     disabled: false,
+    block: false,
     fullWidth: false,
   },
 );
+
+const resolvedTone = computed<ButtonTone>(() => {
+  if (props.tone) {
+    return props.tone;
+  }
+  return props.variant === "secondary" ? "secondary" : "primary";
+});
+
+const isBlock = computed(() => props.block || props.fullWidth);
 
 defineEmits<{
   click: [event: MouseEvent];
@@ -41,63 +94,212 @@ defineEmits<{
 
 <style lang="scss" scoped>
 .ui-button {
-  @include mx.pu-font(label-large);
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: var(--sys-spacing-sm);
-  min-height: var(--sys-size-large);
-  padding: var(--sys-spacing-sm) var(--sys-spacing-med);
-  border-radius: var(--sys-radius-xs);
-  border: none;
+  position: relative;
+  min-width: 0;
+  border: 1px solid transparent;
+  text-decoration: none;
+  user-select: none;
+  -webkit-user-select: none;
   cursor: pointer;
   transition:
-    filter 180ms ease,
-    opacity 180ms ease,
     background-color 180ms ease,
     border-color 180ms ease,
-    color 180ms ease;
+    color 180ms ease,
+    box-shadow 180ms ease,
+    transform 180ms ease,
+    opacity 180ms ease,
+    filter 180ms ease;
 
   &:disabled {
     opacity: var(--sys-opacity-disabled);
     cursor: not-allowed;
+    box-shadow: none;
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--sys-color-primary);
+    outline-offset: 2px;
   }
 }
 
+.ui-button--block,
 .ui-button--full-width {
   width: 100%;
 }
 
-.ui-button--primary {
-  background: var(--sys-color-primary);
-  color: var(--sys-color-on-primary);
-
-  &:hover:not(:disabled) {
-    filter: brightness(0.95);
-  }
+.ui-button--appearance-rect {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--sys-spacing-xs);
+  border-radius: var(--sys-radius-sm);
 }
 
-.ui-button--secondary {
-  border: 1px solid var(--sys-color-outline);
+.ui-button--appearance-pill {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--sys-spacing-xs);
+  border-radius: 999px;
+}
+
+.ui-button--appearance-rect.ui-button--tone-primary {
+  @include mx.pu-rect-action(primary, default);
+}
+
+.ui-button--appearance-rect.ui-button--tone-secondary {
+  @include mx.pu-rect-action(outline-primary, default);
+}
+
+.ui-button--appearance-rect.ui-button--tone-outline {
+  @include mx.pu-rect-action(outline, default);
+}
+
+.ui-button--appearance-rect.ui-button--tone-surface {
+  @include mx.pu-rect-action(surface, default);
+}
+
+.ui-button--appearance-rect.ui-button--tone-danger {
+  @include mx.pu-rect-action(danger, default);
+}
+
+.ui-button--appearance-rect.ui-button--tone-ghost {
   background: transparent;
   color: var(--sys-color-on-surface);
 
   &:hover:not(:disabled) {
-    background: var(--sys-color-surface-container);
+    background: color-mix(
+      in srgb,
+      var(--sys-color-surface-container-high) 68%,
+      transparent
+    );
   }
+}
+
+.ui-button--appearance-pill.ui-button--tone-primary {
+  @include mx.pu-pill-action(solid-primary, default);
+}
+
+.ui-button--appearance-pill.ui-button--tone-secondary {
+  @include mx.pu-pill-action(solid-secondary, default);
+}
+
+.ui-button--appearance-pill.ui-button--tone-outline {
+  @include mx.pu-pill-action(outline-transparent, default);
+}
+
+.ui-button--appearance-pill.ui-button--tone-surface {
+  background: var(--sys-color-surface-container-lowest);
+  border-color: var(--sys-color-outline-variant);
+  color: var(--sys-color-on-surface);
+}
+
+.ui-button--appearance-pill.ui-button--tone-danger {
+  background: transparent;
+  border-color: var(--sys-color-error);
+  color: var(--sys-color-error);
+}
+
+.ui-button--appearance-pill.ui-button--tone-ghost {
+  @include mx.pu-pill-action(transparent, default);
+}
+
+.ui-button--size-sm {
+  @include mx.pu-font(label-medium);
+}
+
+.ui-button--size-md {
+  @include mx.pu-font(label-large);
+}
+
+.ui-button--size-lg {
+  @include mx.pu-font(title-small);
+}
+
+.ui-button--appearance-rect.ui-button--size-sm {
+  min-height: var(--sys-size-medium);
+  padding: var(--sys-spacing-xs) var(--sys-spacing-sm);
+}
+
+.ui-button--appearance-rect.ui-button--size-md {
+  min-height: var(--sys-size-large);
+  padding: var(--sys-spacing-sm) var(--sys-spacing-med);
+}
+
+.ui-button--appearance-rect.ui-button--size-lg {
+  min-height: calc(var(--sys-size-large) + var(--sys-spacing-sm));
+  padding: var(--sys-spacing-med) var(--sys-spacing-lg);
+}
+
+.ui-button--appearance-pill.ui-button--size-sm {
+  min-height: var(--sys-size-medium);
+  padding: var(--sys-spacing-xs) var(--sys-spacing-sm);
+}
+
+.ui-button--appearance-pill.ui-button--size-md {
+  min-height: var(--sys-size-large);
+  padding: var(--sys-spacing-sm) var(--sys-spacing-med);
+}
+
+.ui-button--appearance-pill.ui-button--size-lg {
+  min-height: calc(var(--sys-size-large) + var(--sys-spacing-sm));
+  padding: var(--sys-spacing-sm) var(--sys-spacing-lg);
+}
+
+.ui-button--appearance-pill.ui-button--tone-surface:hover:not(:disabled),
+.ui-button--appearance-pill.ui-button--tone-danger:hover:not(:disabled),
+.ui-button--appearance-pill.ui-button--tone-ghost:hover:not(:disabled),
+.ui-button--appearance-rect.ui-button--tone-primary:hover:not(:disabled),
+.ui-button--appearance-rect.ui-button--tone-secondary:hover:not(:disabled),
+.ui-button--appearance-rect.ui-button--tone-outline:hover:not(:disabled),
+.ui-button--appearance-rect.ui-button--tone-surface:hover:not(:disabled),
+.ui-button--appearance-rect.ui-button--tone-danger:hover:not(:disabled) {
+  filter: brightness(0.98);
+}
+
+.ui-button:active:not(:disabled) {
+  transform: scale(0.99);
 }
 
 .ui-button__content {
   min-width: 0;
 }
 
+.ui-button__leading,
+.ui-button__trailing,
 .ui-button__spinner {
-  width: 20px;
-  height: 20px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.ui-button__leading :deep([class^="i-"]),
+.ui-button__leading :deep([class*=" i-"]),
+.ui-button__trailing :deep([class^="i-"]),
+.ui-button__trailing :deep([class*=" i-"]) {
+  @include mx.pu-icon(sm);
+}
+
+.ui-button__spinner {
+  width: 1em;
+  height: 1em;
   border: 2px solid transparent;
   border-top-color: currentColor;
   border-radius: 50%;
   animation: ui-button-spin 0.8s linear infinite;
+}
+
+.is-loading .ui-button__content {
+  opacity: 0.92;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ui-button,
+  .ui-button__spinner {
+    transition: none !important;
+    animation: none !important;
+  }
 }
 
 @keyframes ui-button-spin {

--- a/apps/frontend/src/shared/ui/containers/SurfaceCard.vue
+++ b/apps/frontend/src/shared/ui/containers/SurfaceCard.vue
@@ -1,0 +1,67 @@
+<template>
+  <component
+    :is="as"
+    class="surface-card"
+    :class="[`surface-card--tone-${tone}`, `surface-card--gap-${gap}`]"
+  >
+    <slot />
+  </component>
+</template>
+
+<script setup lang="ts">
+type SurfaceCardTone = "section" | "inset-high" | "outline";
+type SurfaceCardGap = "none" | "xs" | "sm" | "md" | "lg";
+
+withDefaults(
+  defineProps<{
+    as?: string;
+    tone?: SurfaceCardTone;
+    gap?: SurfaceCardGap;
+  }>(),
+  {
+    as: "section",
+    tone: "section",
+    gap: "sm",
+  },
+);
+</script>
+
+<style lang="scss" scoped>
+.surface-card {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.surface-card--tone-section {
+  @include mx.pu-surface-card(section);
+}
+
+.surface-card--tone-inset-high {
+  @include mx.pu-surface-card(inset-high);
+}
+
+.surface-card--tone-outline {
+  @include mx.pu-surface-card(outline);
+}
+
+.surface-card--gap-none {
+  gap: 0;
+}
+
+.surface-card--gap-xs {
+  gap: var(--sys-spacing-xs);
+}
+
+.surface-card--gap-sm {
+  gap: var(--sys-spacing-sm);
+}
+
+.surface-card--gap-md {
+  gap: var(--sys-spacing-med);
+}
+
+.surface-card--gap-lg {
+  gap: var(--sys-spacing-lg);
+}
+</style>

--- a/apps/frontend/src/shared/ui/display/Chip.vue
+++ b/apps/frontend/src/shared/ui/display/Chip.vue
@@ -1,0 +1,94 @@
+<template>
+  <component
+    :is="as"
+    class="ui-chip"
+    :class="[`ui-chip--tone-${tone}`, `ui-chip--size-${size}`]"
+  >
+    <slot />
+  </component>
+</template>
+
+<script setup lang="ts">
+type ChipTone =
+  | "secondary"
+  | "primary"
+  | "surface"
+  | "outline"
+  | "danger"
+  | "warning";
+type ChipSize = "sm" | "md";
+
+withDefaults(
+  defineProps<{
+    as?: string;
+    tone?: ChipTone;
+    size?: ChipSize;
+  }>(),
+  {
+    as: "span",
+    tone: "secondary",
+    size: "md",
+  },
+);
+</script>
+
+<style lang="scss" scoped>
+.ui-chip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: fit-content;
+  border: 1px solid transparent;
+  border-radius: 999px;
+  white-space: nowrap;
+}
+
+.ui-chip--size-sm {
+  @include mx.pu-font(label-small);
+  padding: 0 calc(var(--sys-spacing-sm) - 2px);
+  min-height: var(--sys-size-small);
+}
+
+.ui-chip--size-md {
+  @include mx.pu-font(label-medium);
+  padding: var(--sys-spacing-xs) var(--sys-spacing-sm);
+  min-height: var(--sys-size-medium);
+}
+
+.ui-chip--tone-secondary {
+  background: var(--sys-color-secondary-container);
+  color: var(--sys-color-on-secondary-container);
+}
+
+.ui-chip--tone-primary {
+  background: var(--sys-color-primary-container);
+  color: var(--sys-color-on-primary-container);
+}
+
+.ui-chip--tone-surface {
+  background: var(--sys-color-surface-container-lowest);
+  color: var(--sys-color-on-surface);
+  border-color: var(--sys-color-outline-variant);
+}
+
+.ui-chip--tone-outline {
+  background: transparent;
+  color: var(--sys-color-on-surface);
+  border-color: var(--sys-color-outline);
+}
+
+.ui-chip--tone-danger {
+  background: var(--sys-color-error-container);
+  color: var(--sys-color-on-error-container);
+}
+
+.ui-chip--tone-warning {
+  background: color-mix(
+    in srgb,
+    var(--sys-color-warning) 18%,
+    var(--sys-color-surface-container-lowest)
+  );
+  color: var(--sys-color-on-surface);
+  border-color: color-mix(in srgb, var(--sys-color-warning) 42%, transparent);
+}
+</style>

--- a/apps/frontend/src/shared/ui/display/ChipGroup.vue
+++ b/apps/frontend/src/shared/ui/display/ChipGroup.vue
@@ -1,0 +1,58 @@
+<template>
+  <component
+    :is="as"
+    class="chip-group"
+    :class="[`chip-group--gap-${gap}`, `chip-group--align-${align}`]"
+  >
+    <slot />
+  </component>
+</template>
+
+<script setup lang="ts">
+type ChipGroupGap = "xs" | "sm" | "md";
+type ChipGroupAlign = "start" | "center" | "end";
+
+withDefaults(
+  defineProps<{
+    as?: string;
+    gap?: ChipGroupGap;
+    align?: ChipGroupAlign;
+  }>(),
+  {
+    as: "div",
+    gap: "xs",
+    align: "start",
+  },
+);
+</script>
+
+<style lang="scss" scoped>
+.chip-group {
+  display: flex;
+  flex-wrap: wrap;
+}
+
+.chip-group--gap-xs {
+  gap: var(--sys-spacing-xs);
+}
+
+.chip-group--gap-sm {
+  gap: var(--sys-spacing-sm);
+}
+
+.chip-group--gap-md {
+  gap: var(--sys-spacing-med);
+}
+
+.chip-group--align-start {
+  justify-content: flex-start;
+}
+
+.chip-group--align-center {
+  justify-content: center;
+}
+
+.chip-group--align-end {
+  justify-content: flex-end;
+}
+</style>

--- a/apps/frontend/src/shared/ui/display/InfoRow.vue
+++ b/apps/frontend/src/shared/ui/display/InfoRow.vue
@@ -1,0 +1,94 @@
+<template>
+  <div
+    class="info-row"
+    :class="[
+      `info-row--layout-${layout}`,
+      `info-row--align-${align}`,
+      { 'info-row--collapse': collapseOnMobile },
+    ]"
+  >
+    <div v-if="label || $slots.label" class="info-row__label">
+      <slot name="label">
+        {{ label }}
+      </slot>
+    </div>
+    <div class="info-row__value">
+      <slot>
+        {{ value }}
+      </slot>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+type InfoRowLayout = "inline" | "stack";
+type InfoRowAlign = "start" | "end";
+
+withDefaults(
+  defineProps<{
+    label?: string;
+    value?: string | number | null;
+    layout?: InfoRowLayout;
+    align?: InfoRowAlign;
+    collapseOnMobile?: boolean;
+  }>(),
+  {
+    label: undefined,
+    value: null,
+    layout: "inline",
+    align: "end",
+    collapseOnMobile: true,
+  },
+);
+</script>
+
+<style lang="scss" scoped>
+.info-row {
+  display: flex;
+  gap: var(--sys-spacing-sm);
+  min-width: 0;
+}
+
+.info-row--layout-inline {
+  align-items: center;
+  justify-content: space-between;
+}
+
+.info-row--layout-stack {
+  flex-direction: column;
+  align-items: flex-start;
+}
+
+.info-row__label {
+  @include mx.pu-font(label-large);
+  color: var(--sys-color-on-surface-variant);
+  flex-shrink: 0;
+}
+
+.info-row__value {
+  @include mx.pu-font(body-medium);
+  color: var(--sys-color-on-surface);
+  min-width: 0;
+  flex: 1;
+}
+
+.info-row--align-end .info-row__value {
+  text-align: right;
+}
+
+.info-row--layout-stack .info-row__value,
+.info-row--align-start .info-row__value {
+  text-align: left;
+}
+
+@media (max-width: 879px) {
+  .info-row--layout-inline.info-row--collapse {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .info-row--layout-inline.info-row--collapse .info-row__value {
+    text-align: left;
+  }
+}
+</style>

--- a/apps/frontend/src/shared/ui/feedback/EmptyState.vue
+++ b/apps/frontend/src/shared/ui/feedback/EmptyState.vue
@@ -1,0 +1,108 @@
+<template>
+  <SurfaceCard
+    :as="as"
+    :tone="tone"
+    :gap="compact ? 'xs' : 'sm'"
+    class="empty-state"
+    :class="`empty-state--align-${align}`"
+  >
+    <span
+      v-if="icon"
+      class="empty-state__icon"
+      :class="icon"
+      aria-hidden="true"
+    ></span>
+
+    <div class="empty-state__copy">
+      <h2 class="empty-state__title">{{ title }}</h2>
+      <p v-if="description" class="empty-state__description">
+        {{ description }}
+      </p>
+      <div v-if="$slots.default" class="empty-state__body">
+        <slot />
+      </div>
+    </div>
+
+    <div v-if="$slots.actions" class="empty-state__actions">
+      <slot name="actions" />
+    </div>
+  </SurfaceCard>
+</template>
+
+<script setup lang="ts">
+import SurfaceCard from "@/shared/ui/containers/SurfaceCard.vue";
+
+type EmptyStateAlign = "start" | "center";
+type EmptyStateTone = "section" | "outline";
+
+withDefaults(
+  defineProps<{
+    as?: string;
+    title: string;
+    description?: string;
+    icon?: string;
+    compact?: boolean;
+    align?: EmptyStateAlign;
+    tone?: EmptyStateTone;
+  }>(),
+  {
+    as: "section",
+    description: undefined,
+    icon: undefined,
+    compact: false,
+    align: "center",
+    tone: "outline",
+  },
+);
+</script>
+
+<style lang="scss" scoped>
+.empty-state {
+  align-items: stretch;
+}
+
+.empty-state--align-center {
+  text-align: center;
+  align-items: center;
+}
+
+.empty-state--align-start {
+  text-align: left;
+  align-items: flex-start;
+}
+
+.empty-state__icon {
+  @include mx.pu-icon(lg, true);
+  color: var(--sys-color-primary);
+}
+
+.empty-state__copy {
+  min-width: 0;
+}
+
+.empty-state__title,
+.empty-state__description {
+  margin: 0;
+}
+
+.empty-state__title {
+  @include mx.pu-font(title-medium);
+  color: var(--sys-color-on-surface);
+}
+
+.empty-state__description,
+.empty-state__body {
+  @include mx.pu-font(body-medium);
+  color: var(--sys-color-on-surface-variant);
+}
+
+.empty-state__body {
+  margin-top: var(--sys-spacing-xs);
+}
+
+.empty-state__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--sys-spacing-sm);
+}
+</style>

--- a/apps/frontend/src/shared/ui/feedback/InlineNotice.vue
+++ b/apps/frontend/src/shared/ui/feedback/InlineNotice.vue
@@ -1,0 +1,148 @@
+<template>
+  <div class="inline-notice" :class="`inline-notice--${tone}`" :role="role">
+    <span class="inline-notice__icon" :class="iconClass" aria-hidden="true"></span>
+
+    <div class="inline-notice__content">
+      <p v-if="title" class="inline-notice__title">{{ title }}</p>
+      <p v-if="message" class="inline-notice__message">{{ message }}</p>
+      <div v-if="$slots.default" class="inline-notice__body">
+        <slot />
+      </div>
+    </div>
+
+    <button
+      v-if="dismissible"
+      type="button"
+      class="inline-notice__close"
+      :aria-label="closeLabel"
+      @click="$emit('close')"
+    >
+      <span class="i-mdi-close" aria-hidden="true"></span>
+    </button>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from "vue";
+import { useI18n } from "vue-i18n";
+
+type InlineNoticeTone = "info" | "success" | "warning" | "error";
+
+const props = withDefaults(
+  defineProps<{
+    tone?: InlineNoticeTone;
+    title?: string;
+    message?: string;
+    dismissible?: boolean;
+    closeLabel?: string;
+  }>(),
+  {
+    tone: "info",
+    title: undefined,
+    message: undefined,
+    dismissible: false,
+    closeLabel: undefined,
+  },
+);
+
+defineEmits<{
+  close: [];
+}>();
+
+const { t } = useI18n();
+
+const role = computed(() =>
+  props.tone === "error" || props.tone === "warning" ? "alert" : "status",
+);
+
+const closeLabel = computed(() => props.closeLabel ?? t("common.close"));
+
+const iconClass = computed(() => {
+  if (props.tone === "success") return "i-mdi-check-circle-outline";
+  if (props.tone === "warning") return "i-mdi-alert-outline";
+  if (props.tone === "error") return "i-mdi-alert-circle-outline";
+  return "i-mdi-information-outline";
+});
+</script>
+
+<style lang="scss" scoped>
+.inline-notice {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: var(--sys-spacing-sm);
+  align-items: start;
+  border-radius: var(--sys-radius-md);
+  padding: var(--sys-spacing-sm) var(--sys-spacing-med);
+}
+
+.inline-notice--info {
+  background: var(--sys-color-surface-container-high);
+  color: var(--sys-color-on-surface);
+}
+
+.inline-notice--success {
+  background: color-mix(
+    in srgb,
+    var(--sys-color-primary-container) 72%,
+    var(--sys-color-surface-container-lowest)
+  );
+  color: var(--sys-color-on-surface);
+}
+
+.inline-notice--warning {
+  background: color-mix(
+    in srgb,
+    var(--sys-color-warning) 18%,
+    var(--sys-color-surface-container-lowest)
+  );
+  color: var(--sys-color-on-surface);
+}
+
+.inline-notice--error {
+  background: var(--sys-color-error-container);
+  color: var(--sys-color-on-error-container);
+}
+
+.inline-notice__icon {
+  @include mx.pu-icon(md, true);
+  margin-top: 2px;
+}
+
+.inline-notice__content {
+  min-width: 0;
+}
+
+.inline-notice__title,
+.inline-notice__message {
+  margin: 0;
+}
+
+.inline-notice__title {
+  @include mx.pu-font(label-large);
+}
+
+.inline-notice__message,
+.inline-notice__body {
+  @include mx.pu-font(body-medium);
+}
+
+.inline-notice__body {
+  margin-top: var(--sys-spacing-xs);
+}
+
+.inline-notice__close {
+  @include mx.pu-icon(sm, true);
+  width: var(--sys-size-medium);
+  height: var(--sys-size-medium);
+  border: none;
+  border-radius: 999px;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+}
+
+.inline-notice__close:focus-visible {
+  outline: 2px solid currentColor;
+  outline-offset: 2px;
+}
+</style>

--- a/apps/frontend/src/shared/ui/forms/FormField.vue
+++ b/apps/frontend/src/shared/ui/forms/FormField.vue
@@ -1,0 +1,86 @@
+<template>
+  <component :is="as" class="form-field">
+    <div v-if="label || $slots.labelTrailing" class="form-field__header">
+      <label v-if="label" class="form-field__label" :for="forId">
+        {{ label }}
+        <span v-if="required" class="form-field__required" aria-hidden="true">
+          *
+        </span>
+      </label>
+      <slot name="labelTrailing" />
+    </div>
+
+    <div class="form-field__control">
+      <slot />
+    </div>
+
+    <p v-if="error" class="form-field__message form-field__message--error">
+      {{ error }}
+    </p>
+    <p v-else-if="hint" class="form-field__message form-field__message--hint">
+      {{ hint }}
+    </p>
+  </component>
+</template>
+
+<script setup lang="ts">
+withDefaults(
+  defineProps<{
+    as?: string;
+    label?: string;
+    forId?: string;
+    hint?: string | null;
+    error?: string | null;
+    required?: boolean;
+  }>(),
+  {
+    as: "div",
+    label: undefined,
+    forId: undefined,
+    hint: null,
+    error: null,
+    required: false,
+  },
+);
+</script>
+
+<style lang="scss" scoped>
+.form-field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sys-spacing-xs);
+}
+
+.form-field__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--sys-spacing-sm);
+}
+
+.form-field__label {
+  @include mx.pu-font(label-large);
+  color: var(--sys-color-on-surface-variant);
+}
+
+.form-field__required {
+  color: var(--sys-color-error);
+}
+
+.form-field__control {
+  min-width: 0;
+}
+
+.form-field__message {
+  margin: 0;
+  @include mx.pu-font(body-small);
+}
+
+.form-field__message--hint {
+  color: var(--sys-color-on-surface-variant);
+}
+
+.form-field__message--error {
+  color: var(--sys-color-error);
+}
+</style>

--- a/apps/frontend/src/shared/ui/identity/Avatar.vue
+++ b/apps/frontend/src/shared/ui/identity/Avatar.vue
@@ -1,0 +1,155 @@
+<template>
+  <div
+    class="ui-avatar"
+    :class="[
+      `ui-avatar--size-${size}`,
+      `ui-avatar--shape-${shape}`,
+      { 'ui-avatar--bordered': bordered },
+    ]"
+  >
+    <img
+      v-if="src"
+      class="ui-avatar__image"
+      :src="src"
+      :alt="resolvedAlt"
+      loading="lazy"
+      decoding="async"
+    />
+    <div
+      v-else
+      class="ui-avatar__fallback"
+      :aria-hidden="fallbackAriaHidden"
+      :role="fallbackAriaHidden ? undefined : 'img'"
+      :aria-label="fallbackAriaHidden ? undefined : resolvedAlt"
+    >
+      <span>{{ fallbackText }}</span>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from "vue";
+
+type AvatarSize = "sm" | "md" | "lg" | "xl";
+type AvatarShape = "circle" | "rounded";
+
+const props = withDefaults(
+  defineProps<{
+    src?: string | null;
+    alt?: string;
+    name?: string | null;
+    fallback?: string | null;
+    size?: AvatarSize;
+    shape?: AvatarShape;
+    bordered?: boolean;
+  }>(),
+  {
+    src: null,
+    alt: "",
+    name: null,
+    fallback: null,
+    size: "md",
+    shape: "circle",
+    bordered: false,
+  },
+);
+
+const fallbackText = computed(() => {
+  const explicitFallback = props.fallback?.trim();
+  if (explicitFallback) {
+    return explicitFallback;
+  }
+  const normalizedName = props.name?.trim();
+  if (normalizedName) {
+    return normalizedName.slice(0, 1).toUpperCase();
+  }
+  return "?";
+});
+
+const resolvedAlt = computed(() => {
+  if (props.alt.trim().length > 0) {
+    return props.alt;
+  }
+  return props.name?.trim() ?? "";
+});
+
+const fallbackAriaHidden = computed(() => resolvedAlt.value.length === 0);
+</script>
+
+<style lang="scss" scoped>
+.ui-avatar {
+  position: relative;
+  flex-shrink: 0;
+}
+
+.ui-avatar--size-sm {
+  width: 2rem;
+  height: 2rem;
+}
+
+.ui-avatar--size-md {
+  width: 3rem;
+  height: 3rem;
+}
+
+.ui-avatar--size-lg {
+  width: 4.75rem;
+  height: 4.75rem;
+}
+
+.ui-avatar--size-xl {
+  width: 5.5rem;
+  height: 5.5rem;
+}
+
+.ui-avatar--shape-circle,
+.ui-avatar--shape-circle .ui-avatar__image,
+.ui-avatar--shape-circle .ui-avatar__fallback {
+  border-radius: 999px;
+}
+
+.ui-avatar--shape-rounded,
+.ui-avatar--shape-rounded .ui-avatar__image,
+.ui-avatar--shape-rounded .ui-avatar__fallback {
+  border-radius: var(--sys-radius-md);
+}
+
+.ui-avatar--bordered .ui-avatar__image,
+.ui-avatar--bordered .ui-avatar__fallback {
+  border: 1px solid var(--sys-color-outline-variant);
+}
+
+.ui-avatar__image,
+.ui-avatar__fallback {
+  display: flex;
+  width: 100%;
+  height: 100%;
+}
+
+.ui-avatar__image {
+  object-fit: cover;
+}
+
+.ui-avatar__fallback {
+  align-items: center;
+  justify-content: center;
+  background: var(--sys-color-primary-container);
+  color: var(--sys-color-on-primary-container);
+}
+
+.ui-avatar--size-sm .ui-avatar__fallback span {
+  @include mx.pu-font(label-medium);
+}
+
+.ui-avatar--size-md .ui-avatar__fallback span {
+  @include mx.pu-font(title-small);
+}
+
+.ui-avatar--size-lg .ui-avatar__fallback span {
+  @include mx.pu-font(title-large);
+}
+
+.ui-avatar--size-xl .ui-avatar__fallback span {
+  @include mx.pu-font(headline-small);
+}
+</style>

--- a/apps/frontend/src/shared/ui/overlay/ConfirmDialog.vue
+++ b/apps/frontend/src/shared/ui/overlay/ConfirmDialog.vue
@@ -1,0 +1,118 @@
+<template>
+  <Modal :open="open" :title="title" :max-width="maxWidth" @close="$emit('close')">
+    <div class="confirm-dialog">
+      <slot>
+        <p v-if="message" class="confirm-dialog__message">{{ message }}</p>
+        <p v-if="description" class="confirm-dialog__description">
+          {{ description }}
+        </p>
+      </slot>
+
+      <div class="confirm-dialog__actions">
+        <Button
+          type="button"
+          appearance="rect"
+          tone="outline"
+          block
+          @click="$emit('close')"
+        >
+          {{ cancelLabelText }}
+        </Button>
+        <Button
+          type="button"
+          appearance="rect"
+          :tone="confirmTone"
+          :loading="loading"
+          :disabled="disabled"
+          block
+          @click="$emit('confirm')"
+        >
+          {{ confirmLabelText }}
+        </Button>
+      </div>
+    </div>
+  </Modal>
+</template>
+
+<script setup lang="ts">
+import { computed } from "vue";
+import { useI18n } from "vue-i18n";
+import Button from "@/shared/ui/actions/Button.vue";
+import Modal from "@/shared/ui/overlay/Modal.vue";
+
+type ConfirmTone = "primary" | "danger" | "secondary";
+
+const props = withDefaults(
+  defineProps<{
+    open: boolean;
+    title: string;
+    message?: string;
+    description?: string;
+    confirmLabel?: string;
+    cancelLabel?: string;
+    confirmTone?: ConfirmTone;
+    loading?: boolean;
+    disabled?: boolean;
+    maxWidth?: string;
+  }>(),
+  {
+    message: undefined,
+    description: undefined,
+    confirmLabel: undefined,
+    cancelLabel: undefined,
+    confirmTone: "primary",
+    loading: false,
+    disabled: false,
+    maxWidth: "420px",
+  },
+);
+
+defineEmits<{
+  close: [];
+  confirm: [];
+}>();
+
+const { t } = useI18n();
+
+const confirmLabelText = computed(() => props.confirmLabel ?? t("common.confirm"));
+const cancelLabelText = computed(() => props.cancelLabel ?? t("common.cancel"));
+</script>
+
+<style lang="scss" scoped>
+.confirm-dialog {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sys-spacing-lg);
+}
+
+.confirm-dialog__message,
+.confirm-dialog__description {
+  margin: 0;
+}
+
+.confirm-dialog__message {
+  @include mx.pu-font(body-medium);
+  color: var(--sys-color-on-surface);
+}
+
+.confirm-dialog__description {
+  @include mx.pu-font(body-small);
+  color: var(--sys-color-on-surface-variant);
+}
+
+.confirm-dialog__actions {
+  display: flex;
+  gap: var(--sys-spacing-sm);
+}
+
+.confirm-dialog__actions :deep(.ui-button) {
+  flex: 1;
+  min-width: 0;
+}
+
+@media (max-width: 640px) {
+  .confirm-dialog__actions {
+    flex-direction: column;
+  }
+}
+</style>


### PR DESCRIPTION
## Summary
- add shared UI primitives (Button, SurfaceCard, FormField, InfoRow, Chip/ChipGroup, InlineNotice, EmptyState, ConfirmDialog, Avatar)
- migrate MePage, UserProfilePage, and AnchorPRPage to compose these primitives and document their intended reuse
- update frontend agent docs so future work picks up the new primitives

## Testing
- pnpm --filter @partner-up-dev/frontend build