### PR TITLE
refactor(frontend): simplify anchor event batch tab navigation

### DIFF
--- a/apps/frontend/src/shared/ui/navigation/TabBar.vue
+++ b/apps/frontend/src/shared/ui/navigation/TabBar.vue
@@ -1,18 +1,20 @@
 <template>
-  <div class="tab-bar" role="tablist" :aria-label="ariaLabel">
-    <button
-      v-for="item in items"
-      :key="item.key"
-      type="button"
-      role="tab"
-      class="tab-bar__tab"
-      :class="{ 'tab-bar__tab--active': modelValue === item.key }"
-      :aria-selected="modelValue === item.key"
-      :disabled="item.disabled === true"
-      @click="handleSelect(item)"
-    >
-      {{ item.label }}
-    </button>
+  <div class="tab-bar">
+    <div class="tab-bar__list" role="tablist" :aria-label="ariaLabel">
+      <button
+        v-for="item in items"
+        :key="item.key"
+        type="button"
+        role="tab"
+        class="tab-bar__tab"
+        :class="{ 'tab-bar__tab--active': modelValue === item.key }"
+        :aria-selected="modelValue === item.key"
+        :disabled="item.disabled === true"
+        @click="handleSelect(item)"
+      >
+        {{ item.label }}
+      </button>
+    </div>
     <slot name="append" />
   </div>
 </template>
@@ -46,13 +48,22 @@ const handleSelect = (item: TabBarItem) => {
 .tab-bar {
   display: flex;
   gap: var(--sys-spacing-sm);
+  align-items: flex-start;
+  padding-bottom: var(--sys-spacing-sm);
+  min-width: 0;
+}
+
+.tab-bar__list {
+  display: flex;
+  gap: var(--sys-spacing-sm);
+  flex: 1 1 auto;
+  min-width: 0;
   overflow-x: auto;
   -webkit-overflow-scrolling: touch;
-  padding-bottom: var(--sys-spacing-sm);
   scrollbar-width: none;
 }
 
-.tab-bar::-webkit-scrollbar {
+.tab-bar__list::-webkit-scrollbar {
   display: none;
 }
 


### PR DESCRIPTION
### Motivation
- The expired-batches dropdown solved the original visibility rule, but it made batch navigation feel indirect and awkward.
- A single chronological tab row is simpler if the page starts on the first actionable batch and keeps the active tab in view.

### Description
- Removed the special expired-batches dropdown flow from `AnchorEventPage` and restored one chronological `TabBar` that includes all batches.
- Updated default list-mode selection to prefer the first `OPEN` batch, then fall back to the first non-expired batch, then the first available batch.
- Added auto-scroll behavior to the shared `TabBar` so the active tab is brought into view on initialization and selection changes.
- Removed the now-unused shared `DropdownSelector` primitive and updated the frontend design note to match the new interaction model.
- Card-mode demand-card aggregation still excludes expired batches.

### Testing
- Ran `pnpm --filter @partner-up-dev/frontend build`