### PR TITLE
Refine Anchor PR IA

### DIFF
--- a/apps/frontend/src/domains/pr/ui/composites/AnchorPRFactsCard.vue
+++ b/apps/frontend/src/domains/pr/ui/composites/AnchorPRFactsCard.vue
@@ -1,0 +1,117 @@
+<template>
+  <SurfaceCard as="section" class="anchor-pr-facts-card" gap="md">
+    <h2 class="facts-title">活动信息</h2>
+
+    <InfoRow :label="t('prCard.location')">
+      {{ location ?? t("prPage.partnerSection.notSet") }}
+    </InfoRow>
+
+    <button
+      v-if="locationGalleryAvailable"
+      class="location-gallery-link"
+      type="button"
+      @click="$emit('view-location-gallery')"
+    >
+      {{ t("prCard.viewLocationImages") }}
+    </button>
+
+    <InfoRow :label="t('prCard.time')">
+      {{ timeText }}
+    </InfoRow>
+
+    <InfoRow :label="t('prCard.preferences')" layout="stack" align="start">
+      <ChipGroup>
+        <Chip v-for="item in preferences" :key="item">
+          {{ item }}
+        </Chip>
+      </ChipGroup>
+      <span v-if="preferences.length === 0" class="facts-empty">
+        {{ t("prPage.partnerSection.notSet") }}
+      </span>
+    </InfoRow>
+
+    <InfoRow label="参与概览" layout="stack" align="start">
+      <p class="facts-overview">{{ participantOverviewText }}</p>
+      <ChipGroup v-if="rosterPreview.length > 0">
+        <Chip v-for="item in rosterPreview" :key="item.partnerId">
+          {{ item.displayName }}
+        </Chip>
+        <span v-if="hasMoreRoster" class="roster-chip-overflow"> ... </span>
+      </ChipGroup>
+      <span v-else class="facts-empty">
+        {{ t("prPage.partnerSection.rosterCurrentEmpty") }}
+      </span>
+    </InfoRow>
+  </SurfaceCard>
+</template>
+
+<script setup lang="ts">
+import { useI18n } from "vue-i18n";
+import SurfaceCard from "@/shared/ui/containers/SurfaceCard.vue";
+import InfoRow from "@/shared/ui/display/InfoRow.vue";
+import Chip from "@/shared/ui/display/Chip.vue";
+import ChipGroup from "@/shared/ui/display/ChipGroup.vue";
+import type { AnchorPRDetailResponse } from "@/domains/pr/queries/useAnchorPR";
+
+type RosterPreviewItem = AnchorPRDetailResponse["partnerSection"]["roster"][number];
+
+defineProps<{
+  location: string | null;
+  timeText: string;
+  preferences: string[];
+  participantOverviewText: string;
+  rosterPreview: readonly RosterPreviewItem[];
+  hasMoreRoster: boolean;
+  locationGalleryAvailable?: boolean;
+}>();
+
+defineEmits<{
+  "view-location-gallery": [];
+}>();
+
+const { t } = useI18n();
+</script>
+
+<style scoped lang="scss">
+.anchor-pr-facts-card {
+  min-width: 0;
+}
+
+.facts-title {
+  margin: 0;
+  @include mx.pu-font(title-medium);
+}
+
+.facts-empty {
+  @include mx.pu-font(body-small);
+  color: var(--sys-color-on-surface-variant);
+}
+
+.facts-overview {
+  margin: 0;
+  @include mx.pu-font(body-medium);
+}
+
+.roster-chip-overflow {
+  @include mx.pu-font(label-medium);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: var(--sys-size-medium);
+  padding: var(--sys-spacing-xs) var(--sys-spacing-sm);
+  border-radius: 999px;
+  background: var(--sys-color-secondary-container);
+  color: var(--sys-color-on-secondary-container);
+}
+
+.location-gallery-link {
+  @include mx.pu-font(label-medium);
+  border: none;
+  padding: 0;
+  color: var(--sys-color-primary);
+  background: transparent;
+  width: fit-content;
+  cursor: pointer;
+  text-decoration: underline;
+}
+</style>

--- a/apps/frontend/src/domains/pr/ui/sections/AnchorPRAwarenessLane.vue
+++ b/apps/frontend/src/domains/pr/ui/sections/AnchorPRAwarenessLane.vue
@@ -1,5 +1,5 @@
 <template>
-  <section class="lane-card">
+  <section class="awareness-lane">
     <header class="lane-header">
       <h2 class="lane-title">
         {{ t("prPage.partnerSection.rosterBoardTitle") }}
@@ -246,9 +246,7 @@ const rosterAvatarFallback = (displayName: string): string => {
 </script>
 
 <style lang="scss" scoped>
-.lane-card {
-  margin-top: var(--sys-spacing-lg);
-  @include mx.pu-surface-card(section);
+.awareness-lane {
   display: flex;
   flex-direction: column;
   gap: var(--sys-spacing-sm);
@@ -276,7 +274,10 @@ const rosterAvatarFallback = (displayName: string): string => {
 .roster-list {
   display: flex;
   flex-direction: column;
-  gap: var(--sys-spacing-sm);
+}
+
+.roster-list > * + * {
+  border-top: 1px solid var(--sys-color-outline-variant);
 }
 
 .roster-list--history {
@@ -311,7 +312,8 @@ const rosterAvatarFallback = (displayName: string): string => {
 }
 
 .roster-history {
-  @include mx.pu-surface-card(outline);
+  padding-top: var(--sys-spacing-sm);
+  border-top: 1px solid var(--sys-color-outline-variant);
 }
 
 .roster-history__summary {
@@ -333,11 +335,11 @@ const rosterAvatarFallback = (displayName: string): string => {
 }
 
 .roster-item {
-  @include mx.pu-surface-card(outline);
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
   gap: var(--sys-spacing-sm);
+  padding: var(--sys-spacing-sm) 0;
 }
 
 .roster-main {
@@ -362,18 +364,13 @@ const rosterAvatarFallback = (displayName: string): string => {
 .roster-link {
   text-decoration: none;
   color: inherit;
-  transition:
-    transform 160ms ease,
-    border-color 160ms ease,
-    background-color 160ms ease;
+  transition: background-color 160ms ease;
 
   &:hover {
-    transform: translateY(-1px);
-    border-color: color-mix(in srgb, var(--sys-color-primary) 40%, transparent);
     background: color-mix(
       in srgb,
       var(--sys-color-primary) 6%,
-      var(--sys-color-surface-container-lowest)
+      transparent
     );
   }
 
@@ -413,10 +410,7 @@ const rosterAvatarFallback = (displayName: string): string => {
 .roster-tag,
 .roster-state {
   @include mx.pu-font(label-small);
-  padding: 2px 8px;
-  border-radius: 999px;
-  background: var(--sys-color-secondary-container);
-  color: var(--sys-color-on-secondary-container);
+  color: var(--sys-color-on-surface-variant);
 }
 
 .roster-state {

--- a/apps/frontend/src/domains/pr/ui/sections/AnchorPRRecoveryLane.vue
+++ b/apps/frontend/src/domains/pr/ui/sections/AnchorPRRecoveryLane.vue
@@ -1,50 +1,52 @@
 <template>
-  <section v-if="hasContent" ref="recoveryRoot" class="lane-card">
+  <section v-if="hasContent" ref="recoveryRoot" class="recovery-lane">
     <section
       v-if="section.fallbacks.sameBatchAlternatives.length > 0"
-      class="recovery-panel"
+      class="recovery-group"
     >
-      <header class="recovery-panel-header">
-        <h2 class="recovery-panel-title">{{ t("prPage.sameBatch.title") }}</h2>
+      <header class="recovery-group__header">
+        <h2 class="recovery-group__title">{{ t("prPage.sameBatch.title") }}</h2>
+        <p class="recovery-group__note">{{ t("prPage.sameBatch.subtitle") }}</p>
       </header>
-      <p class="recovery-panel-note">{{ t("prPage.sameBatch.subtitle") }}</p>
 
       <div class="recovery-links">
         <router-link
           v-for="item in section.fallbacks.sameBatchAlternatives"
           :key="item.id"
           :to="anchorPRDetailPath(item.id)"
-          class="recovery-link-card"
+          class="recovery-link-row"
           @click="handleSameBatchClick(item.id)"
         >
-          <span>{{ item.location }}</span>
-          <span class="recovery-link-meta">{{ t(`prStatus.${item.status}`) }}</span>
+          <span class="recovery-link-row__location">{{ item.location }}</span>
+          <span class="recovery-link-row__meta">{{ t(`prStatus.${item.status}`) }}</span>
         </router-link>
       </div>
     </section>
 
     <section
       v-if="section.fallbacks.alternativeBatches.length > 0"
-      class="recovery-panel"
+      class="recovery-group"
     >
-      <header class="recovery-panel-header">
-        <h2 class="recovery-panel-title">
+      <header class="recovery-group__header">
+        <h2 class="recovery-group__title">
           {{ t("prPage.alternativeBatch.title") }}
         </h2>
+        <p class="recovery-group__note">
+          {{ t("prPage.alternativeBatch.subtitle") }}
+        </p>
       </header>
-      <p class="recovery-panel-note">{{ t("prPage.alternativeBatch.subtitle") }}</p>
 
       <div class="recovery-alternatives">
         <article
           v-for="item in section.fallbacks.alternativeBatches"
           :key="`${item.timeWindow[0]}-${item.timeWindow[1]}`"
-          class="recovery-alt-item"
+          class="recovery-alt-row"
         >
-          <div class="recovery-alt-meta">
+          <div class="recovery-alt-row__meta">
             <strong>{{
               formatWindow(item.timeWindow[0], item.timeWindow[1])
             }}</strong>
-            <span class="recovery-panel-note">{{ item.location }}</span>
+            <span class="recovery-group__note">{{ item.location }}</span>
           </div>
           <button
             class="recovery-primary-btn"
@@ -133,35 +135,32 @@ const handleAcceptAlternativeBatch = (targetTimeWindow: TimeWindow) => {
 </script>
 
 <style lang="scss" scoped>
-.lane-card {
-  margin-top: var(--sys-spacing-lg);
+.recovery-lane {
   display: flex;
   flex-direction: column;
   gap: var(--sys-spacing-lg);
 }
 
-.recovery-panel {
-  @include mx.pu-surface-card(section);
+.recovery-group {
   display: flex;
   flex-direction: column;
   gap: var(--sys-spacing-sm);
 }
 
-.recovery-panel-header {
+.recovery-group__header {
   display: flex;
-  justify-content: space-between;
-  align-items: center;
-  gap: var(--sys-spacing-sm);
+  flex-direction: column;
+  gap: var(--sys-spacing-2xs);
 }
 
-.recovery-panel-title {
+.recovery-group__title {
   margin: 0;
-  @include mx.pu-font(title-medium);
+  @include mx.pu-font(title-small);
 }
 
-.recovery-panel-note {
+.recovery-group__note {
   margin: 0;
-  @include mx.pu-font(body-medium);
+  @include mx.pu-font(body-small);
   color: var(--sys-color-on-surface-variant);
 }
 
@@ -169,35 +168,37 @@ const handleAcceptAlternativeBatch = (targetTimeWindow: TimeWindow) => {
 .recovery-alternatives {
   display: flex;
   flex-direction: column;
-  gap: var(--sys-spacing-sm);
 }
 
-.recovery-link-card,
-.recovery-alt-item {
-  @include mx.pu-surface-card(outline);
+.recovery-link-row,
+.recovery-alt-row {
   display: flex;
   justify-content: space-between;
   align-items: center;
   gap: var(--sys-spacing-sm);
+  padding: var(--sys-spacing-sm) 0;
+  border-top: 1px solid var(--sys-color-outline-variant);
 }
 
-.recovery-link-card {
+.recovery-link-row {
   text-decoration: none;
   color: inherit;
 }
 
-.recovery-link-meta {
-  @include mx.pu-font(label-small);
-  padding: 2px 8px;
-  border-radius: 999px;
-  background: var(--sys-color-secondary-container);
-  color: var(--sys-color-on-secondary-container);
+.recovery-link-row__location {
+  @include mx.pu-font(body-medium);
 }
 
-.recovery-alt-meta {
+.recovery-link-row__meta {
+  @include mx.pu-font(label-small);
+  color: var(--sys-color-on-surface-variant);
+  text-align: right;
+}
+
+.recovery-alt-row__meta {
   display: flex;
   flex-direction: column;
-  gap: var(--sys-spacing-xs);
+  gap: var(--sys-spacing-2xs);
   min-width: 0;
 }
 
@@ -209,9 +210,13 @@ const handleAcceptAlternativeBatch = (targetTimeWindow: TimeWindow) => {
 }
 
 @media (max-width: 879px) {
-  .recovery-alt-item {
+  .recovery-alt-row {
     flex-direction: column;
     align-items: stretch;
+  }
+
+  .recovery-link-row {
+    align-items: flex-start;
   }
 }
 </style>

--- a/apps/frontend/src/pages/AnchorPRPage.vue
+++ b/apps/frontend/src/pages/AnchorPRPage.vue
@@ -35,180 +35,192 @@
         </template>
       </PageHeader>
 
-      <SurfaceCard as="section" class="section-card event-fit-card">
-        <h2 class="section-title">活动信息</h2>
-        <InfoRow :label="t('prCard.location')">
-          {{ prDetail.core.location ?? t("prPage.partnerSection.notSet") }}
-        </InfoRow>
-        <button
-          v-if="locationGallery.length > 0"
-          class="location-gallery-link"
-          type="button"
-          @click="showLocationGalleryModal = true"
-        >
-          {{ t("prCard.viewLocationImages") }}
-        </button>
-        <InfoRow :label="t('prCard.time')">
-          {{ localizedTimeText }}
-        </InfoRow>
-        <InfoRow :label="t('prCard.preferences')" layout="stack" align="start">
-          <ChipGroup>
-            <Chip v-for="item in prDetail.core.preferences" :key="item">
-              {{ item }}
-            </Chip>
-          </ChipGroup>
-          <span v-if="prDetail.core.preferences.length === 0" class="fit-empty">
-            {{ t("prPage.partnerSection.notSet") }}
-          </span>
-        </InfoRow>
-        <InfoRow label="参与概览" layout="stack" align="start">
-          <p class="fit-overview">{{ participantOverviewText }}</p>
-          <ChipGroup>
-            <Chip v-for="item in rosterPreview" :key="item.partnerId">
-              {{ item.displayName }}
-            </Chip>
-            <span v-if="hasMoreRoster" class="roster-chip-overflow"> ... </span>
-          </ChipGroup>
-        </InfoRow>
-      </SurfaceCard>
-
-      <section v-if="releaseNoticeText" class="section-card released-notice">
-        <p class="released-notice__text">{{ releaseNoticeText }}</p>
-      </section>
-
-      <section
-        v-for="action in dockActions"
-        :key="action.key"
-        class="section-card"
-      >
-        <button
-          class="action-btn"
-          :class="{
-            'action-btn--danger': action.tone === 'danger',
-            'action-btn--secondary': action.tone === 'secondary',
-            'action-btn--surface': action.tone === 'surface',
-          }"
-          type="button"
-          :disabled="action.disabled || action.pending"
-          @click="handleDockAction(action)"
-        >
-          {{ action.pending ? action.pendingLabel : action.label }}
-        </button>
-        <p v-if="action.tip" class="action-tip">{{ action.tip }}</p>
-        <p v-if="action.key === 'JOIN' && releaseNoticeText" class="action-tip">
-          {{ releaseNoticeText }}
-        </p>
-      </section>
-      <p
-        v-if="primaryActionErrorMessage"
-        class="action-error page-action-error"
-      >
-        {{ primaryActionErrorMessage }}
-      </p>
-
-      <AnchorPRRecoveryLane
-        v-if="showRecoveryLane"
-        :pr-id="id"
-        :section="prDetail.partnerSection"
-        :accept-alternative-batch-pending="
-          acceptAlternativeBatchMutation.isPending.value
-        "
-        @accept-alternative-batch="handleAcceptAlternativeBatch"
+      <AnchorPRFactsCard
+        class="facts-card"
+        :location="prDetail.core.location ?? null"
+        :time-text="localizedTimeText"
+        :preferences="prDetail.core.preferences"
+        :participant-overview-text="participantOverviewText"
+        :roster-preview="rosterPreview"
+        :has-more-roster="hasMoreRoster"
+        :location-gallery-available="locationGallery.length > 0"
+        @view-location-gallery="showLocationGalleryModal = true"
       />
 
-      <WeChatNotificationSubscriptionsCard
-        v-if="showNotificationSubscriptionsCard"
-        :title="t('prPage.notificationSubscriptions.title')"
-      >
-        <APRNotificationSubscriptions
-          :updating-label="t('prPage.wechatReminder.updating')"
-          outline-profile="surface"
+      <section v-if="showContextualActionArea" class="contextual-area">
+        <InlineNotice
+          v-if="releaseNoticeText"
+          tone="warning"
+          :message="releaseNoticeText"
         />
-      </WeChatNotificationSubscriptionsCard>
 
-      <section class="section-card subsidy-card">
-        <div class="booking-support-entry-card__header">
-          <h2 class="section-title">补贴与报销</h2>
-          <router-link
-            v-if="id !== null"
-            :to="anchorPRBookingSupportPath(id)"
-            class="booking-support-entry-card__action"
+        <InlineNotice
+          v-if="primaryBlockedMessage"
+          tone="warning"
+          :message="primaryBlockedMessage"
+        />
+
+        <div v-if="primaryDockAction" class="primary-action">
+          <Button
+            class="primary-action__button"
+            :tone="buttonToneForAction(primaryDockAction)"
+            :disabled="primaryDockAction.disabled"
+            :loading="primaryDockAction.pending"
+            block
+            @click="handleDockAction(primaryDockAction)"
           >
-            {{ t("prPage.bookingSupportEntry.viewAction") }}
-          </router-link>
+            {{
+              primaryDockAction.pending
+                ? primaryDockAction.pendingLabel
+                : primaryDockAction.label
+            }}
+          </Button>
+          <p v-if="primaryDockAction.tip" class="action-tip">
+            {{ primaryDockAction.tip }}
+          </p>
         </div>
-        <p class="section-description">{{ bookingSupportSummaryHeadline }}</p>
-        <p class="section-description">{{ bookingSupportSummaryDeadline }}</p>
+
         <p
-          v-for="highlight in bookingSupportHighlights"
-          :key="highlight"
-          class="section-description"
+          v-if="primaryActionErrorMessage"
+          class="action-error page-action-error"
         >
-          {{ highlight }}
+          {{ primaryActionErrorMessage }}
         </p>
-        <button
-          class="action-btn action-btn--surface"
-          type="button"
-          :disabled="
-            reimbursementButtonDisabled || reimbursementQuery.isLoading.value
+
+        <AnchorPRRecoveryLane
+          v-if="showRecoveryLane"
+          :pr-id="id"
+          :section="prDetail.partnerSection"
+          :accept-alternative-batch-pending="
+            acceptAlternativeBatchMutation.isPending.value
           "
-          @click="goBookingSupport"
-        >
-          {{ reimbursementButtonLabel }}
-        </button>
-        <p v-if="reimbursementDisabledTip" class="action-tip">
-          {{ reimbursementDisabledTip }}
-        </p>
+          @accept-alternative-batch="handleAcceptAlternativeBatch"
+        />
       </section>
 
-      <section class="section-card">
-        <h2 class="section-title">分享邀请</h2>
-        <button
-          class="action-btn action-btn--surface"
-          type="button"
-          @click="showShareDrawer = true"
-        >
-          分享 / 邀请
-        </button>
+      <section class="utility-area">
+        <section class="utility-row">
+          <div class="utility-row__main">
+            <div class="utility-row__content">
+              <h2 class="utility-row__title">补贴与报销</h2>
+              <p class="utility-row__description">
+                {{ bookingSupportSummaryHeadline }}
+              </p>
+              <p class="utility-row__description">
+                {{ bookingSupportSummaryDeadline }}
+              </p>
+              <p
+                v-for="highlight in bookingSupportHighlights"
+                :key="highlight"
+                class="utility-row__description"
+              >
+                {{ highlight }}
+              </p>
+            </div>
+            <div class="utility-row__actions">
+              <Button tone="outline" @click="goBookingSupport">
+                {{ t("prPage.bookingSupportEntry.viewAction") }}
+              </Button>
+              <Button
+                v-if="showReimbursementShortcut"
+                tone="surface"
+                @click="goBookingSupport"
+              >
+                {{ reimbursementButtonLabel }}
+              </Button>
+            </div>
+          </div>
+        </section>
+
+        <section class="utility-row">
+          <div class="utility-row__main">
+            <div class="utility-row__content">
+              <h2 class="utility-row__title">分享邀请</h2>
+              <p class="utility-row__description">
+                把当前活动分享给合适的搭子。
+              </p>
+            </div>
+            <div class="utility-row__actions">
+              <Button tone="outline" @click="showShareDrawer = true">
+                分享 / 邀请
+              </Button>
+            </div>
+          </div>
+        </section>
+
+        <section v-if="showInlineReminderSubscriptions" class="utility-row">
+          <div class="utility-row__content utility-row__content--stack">
+            <h2 class="utility-row__title">
+              {{ t("prPage.notificationSubscriptions.title") }}
+            </h2>
+            <APRNotificationSubscriptions
+              :updating-label="t('prPage.wechatReminder.updating')"
+              outline-profile="surface"
+            />
+          </div>
+        </section>
+
+        <section v-if="showTopLevelExitAction" class="utility-row">
+          <div class="utility-row__main">
+            <div class="utility-row__content">
+              <h2 class="utility-row__title">退出</h2>
+              <p class="utility-row__description">
+                退出后你的参与名额会被释放。
+              </p>
+            </div>
+            <div class="utility-row__actions">
+              <Button
+                tone="danger"
+                :loading="sharedActions.exitPending.value"
+                @click="requestExitWithConfirm"
+              >
+                {{ t("prPage.exit") }}
+              </Button>
+            </div>
+          </div>
+          <p v-if="exitActionError" class="action-error">{{ exitActionError }}</p>
+        </section>
       </section>
 
       <details class="context-details">
         <summary class="context-summary">更多信息</summary>
+        <div class="context-details__body">
+          <AnchorPRAwarenessLane
+            :pr-id="prDetail.id"
+            :section="prDetail.partnerSection"
+          />
 
-        <AnchorPRAwarenessLane
-          :pr-id="prDetail.id"
-          :section="prDetail.partnerSection"
-        />
+          <section
+            v-if="showReminderSubscriptionsInMoreInfo"
+            class="context-section"
+          >
+            <h2 class="context-section__title">
+              {{ t("prPage.notificationSubscriptions.title") }}
+            </h2>
+            <APRNotificationSubscriptions
+              :updating-label="t('prPage.wechatReminder.updating')"
+              outline-profile="surface"
+            />
+          </section>
 
-        <section
-          v-if="prDetail.partnerSection.viewer.isParticipant"
-          class="section-card"
-        >
-          <h2 class="section-title">退出</h2>
-          <button
-            class="action-btn action-btn--danger"
-            type="button"
-            :disabled="
-              !sharedActions.canExit.value || sharedActions.exitPending.value
-            "
-            @click="requestExitWithConfirm"
-          >
-            {{
-              sharedActions.exitPending.value
-                ? t("prPage.exiting")
-                : t("prPage.exit")
-            }}
-          </button>
-          <p
-            v-if="!sharedActions.canExit.value && exitBlockedTip"
-            class="action-tip"
-          >
-            {{ exitBlockedTip }}
-          </p>
-          <p v-if="exitActionError" class="action-error">
-            {{ exitActionError }}
-          </p>
-        </section>
+          <section v-if="showMoreInfoExitArea" class="context-section">
+            <h2 class="context-section__title">退出</h2>
+            <Button
+              tone="danger"
+              :disabled="!sharedActions.canExit.value"
+              :loading="sharedActions.exitPending.value"
+              @click="requestExitWithConfirm"
+            >
+              {{ t("prPage.exit") }}
+            </Button>
+            <p v-if="exitBlockedTip" class="action-tip">
+              {{ exitBlockedTip }}
+            </p>
+            <p v-if="exitActionError" class="action-error">
+              {{ exitActionError }}
+            </p>
+          </section>
+        </div>
       </details>
 
       <BottomDrawer
@@ -380,17 +392,14 @@ import { useI18n } from "vue-i18n";
 import type { PRId } from "@partner-up-dev/backend";
 import LoadingIndicator from "@/shared/ui/feedback/LoadingIndicator.vue";
 import ErrorToast from "@/shared/ui/feedback/ErrorToast.vue";
+import InlineNotice from "@/shared/ui/feedback/InlineNotice.vue";
 import Modal from "@/shared/ui/overlay/Modal.vue";
 import ConfirmDialog from "@/shared/ui/overlay/ConfirmDialog.vue";
 import BottomDrawer from "@/shared/ui/overlay/BottomDrawer.vue";
-import SurfaceCard from "@/shared/ui/containers/SurfaceCard.vue";
-import InfoRow from "@/shared/ui/display/InfoRow.vue";
-import Chip from "@/shared/ui/display/Chip.vue";
-import ChipGroup from "@/shared/ui/display/ChipGroup.vue";
+import Button from "@/shared/ui/actions/Button.vue";
 import PRLocationGalleryModal from "@/domains/pr/ui/modals/PRLocationGalleryModal.vue";
 import EditPRContentModal from "@/domains/pr/ui/modals/EditPRContentModal.vue";
 import UpdatePRStatusModal from "@/domains/pr/ui/modals/UpdatePRStatusModal.vue";
-import WeChatNotificationSubscriptionsCard from "@/shared/ui/sections/WeChatNotificationSubscriptionsCard.vue";
 import APRNotificationSubscriptions from "@/shared/ui/sections/APRNotificationSubscriptions.vue";
 import ContactSupportFooter from "@/domains/support/ui/sections/ContactSupportFooter.vue";
 import PageScaffold from "@/shared/ui/layout/PageScaffold.vue";
@@ -399,6 +408,7 @@ import PRStatusBadge from "@/domains/pr/ui/primitives/PRStatusBadge.vue";
 import PRShareSection from "@/domains/pr/ui/sections/PRShareSection.vue";
 import AnchorPRAwarenessLane from "@/domains/pr/ui/sections/AnchorPRAwarenessLane.vue";
 import AnchorPRRecoveryLane from "@/domains/pr/ui/sections/AnchorPRRecoveryLane.vue";
+import AnchorPRFactsCard from "@/domains/pr/ui/composites/AnchorPRFactsCard.vue";
 import {
   useAcceptAnchorAlternativeBatch,
   useAnchorPR,
@@ -440,9 +450,7 @@ type RosterState =
 type DockActionKey =
   | "JOIN"
   | "CONFIRM"
-  | "CHECKIN_ATTENDED"
-  | "CREATOR_EDIT"
-  | "CREATOR_STATUS";
+  | "CHECKIN_ATTENDED";
 
 type DockActionItem = {
   key: DockActionKey;
@@ -671,22 +679,10 @@ const reimbursementButtonLabel = computed(() => {
   return t("prBookingSupport.reimbursement.title");
 });
 
-const reimbursementDisabledTip = computed(() => {
-  if (!hasEventEnded.value) {
-    return "活动结束后可申请报销。";
-  }
-  const status = reimbursement.value;
-  if (!status) return t("errors.fetchReimbursementStatusFailed");
-  if (status.reason) return reimbursementReasonText(status.reason);
-  if (!status.canRequest)
-    return t("prBookingSupport.reimbursement.reasonAlreadyRequested");
-  return null;
-});
-
 const viewerState = computed<ViewerState>(() => {
   if (!prDetail.value) return "VISITOR_BLOCKED";
-  if (prDetail.value.partnerSection.viewer.isCreator) return "CREATOR";
   if (prDetail.value.partnerSection.viewer.isParticipant) return "PARTICIPANT";
+  if (prDetail.value.partnerSection.viewer.isCreator) return "CREATOR";
   return prDetail.value.partnerSection.viewer.canJoin
     ? "VISITOR_JOINABLE"
     : "VISITOR_BLOCKED";
@@ -695,35 +691,13 @@ const viewerState = computed<ViewerState>(() => {
 const dockActions = computed<DockActionItem[]>(() => {
   if (!prDetail.value) return [];
 
-  if (isCreator.value) {
-    const creatorActions: DockActionItem[] = [];
-    if (sharedActions.showEditContentAction.value) {
-      creatorActions.push({
-        key: "CREATOR_EDIT",
-        label: t("prPage.editContent"),
-        pendingLabel: t("prPage.editContent"),
-        tone: "surface",
-        disabled: false,
-        pending: false,
-        tip: null,
-      });
-    }
-    if (sharedActions.showModifyStatusAction.value) {
-      creatorActions.push({
-        key: "CREATOR_STATUS",
-        label: t("prPage.modifyStatus"),
-        pendingLabel: t("prPage.modifyStatus"),
-        tone: "surface",
-        disabled: false,
-        pending: false,
-        tip: null,
-      });
-    }
-    if (creatorActions.length > 0) return creatorActions.slice(0, 2);
+  const viewer = prDetail.value.partnerSection.viewer;
+  if (viewer.isCreator && !viewer.isParticipant) {
+    return [];
   }
 
-  const viewer = prDetail.value.partnerSection.viewer;
   if (!viewer.isParticipant) {
+    if (!viewer.canJoin) return [];
     return [
       {
         key: "JOIN",
@@ -773,6 +747,59 @@ const dockActions = computed<DockActionItem[]>(() => {
 
 const primaryDockAction = computed(() => dockActions.value[0] ?? null);
 
+const primaryBlockedMessage = computed(() => {
+  const viewer = prDetail.value?.partnerSection.viewer;
+  if (!viewer || viewer.isParticipant || viewer.canJoin) return null;
+  return blockedReasonText(viewer.joinBlockedReason);
+});
+
+const showReminderSubscriptions = computed(() => {
+  const section = prDetail.value?.partnerSection;
+  if (!section?.reminder.supported) return false;
+  return section.viewer.isParticipant;
+});
+
+const isActiveOrLater = computed(() => {
+  const status = prDetail.value?.status;
+  return status === "ACTIVE" || status === "CLOSED" || status === "EXPIRED";
+});
+
+const showInlineReminderSubscriptions = computed(
+  () => showReminderSubscriptions.value && !isActiveOrLater.value,
+);
+
+const showReminderSubscriptionsInMoreInfo = computed(
+  () => showReminderSubscriptions.value && isActiveOrLater.value,
+);
+
+const showReimbursementShortcut = computed(
+  () =>
+    !reimbursementQuery.isLoading.value && !reimbursementButtonDisabled.value,
+);
+
+const showTopLevelExitAction = computed(() => {
+  const viewer = prDetail.value?.partnerSection.viewer;
+  if (!viewer?.isParticipant) return false;
+  return sharedActions.canExit.value;
+});
+
+const showMoreInfoExitArea = computed(() => {
+  const viewer = prDetail.value?.partnerSection.viewer;
+  if (!viewer?.isParticipant) return false;
+  return !showTopLevelExitAction.value;
+});
+
+const showContextualActionArea = computed(
+  () =>
+    Boolean(
+      releaseNoticeText.value ||
+        primaryBlockedMessage.value ||
+        primaryDockAction.value ||
+        primaryActionErrorMessage.value ||
+        showRecoveryLane.value,
+    ),
+);
+
 watch(
   () =>
     [
@@ -796,12 +823,6 @@ watch(
   },
   { immediate: true },
 );
-
-const showNotificationSubscriptionsCard = computed(() => {
-  const section = prDetail.value?.partnerSection;
-  if (!section?.reminder.supported) return false;
-  return section.viewer.isParticipant;
-});
 
 const exitBlockedTip = computed(() => {
   const viewer = prDetail.value?.partnerSection.viewer;
@@ -1017,11 +1038,6 @@ const handleDockAction = async (action: DockActionItem) => {
     attendanceActions.prepareCheckIn();
     return;
   }
-  if (action.key === "CREATOR_EDIT") {
-    handleOpenCreatorEdit();
-    return;
-  }
-  handleOpenCreatorModifyStatus();
 };
 
 const requestExitWithConfirm = () => {
@@ -1149,24 +1165,14 @@ function blockedReasonText(reason: BlockedReason): string {
   }
 }
 
-const reimbursementReasonText = (
-  reason:
-    | "NO_POSTPAID_SUPPORT"
-    | "PR_NOT_CLOSED"
-    | "SLOT_NOT_ELIGIBLE"
-    | "ALREADY_REQUESTED",
-): string => {
-  if (reason === "NO_POSTPAID_SUPPORT") {
-    return t("prBookingSupport.reimbursement.reasonNoPostpaidSupport");
-  }
-  if (reason === "PR_NOT_CLOSED") {
-    return t("prBookingSupport.reimbursement.reasonPrNotClosed");
-  }
-  if (reason === "SLOT_NOT_ELIGIBLE") {
-    return t("prBookingSupport.reimbursement.reasonSlotNotEligible");
-  }
-  return t("prBookingSupport.reimbursement.reasonAlreadyRequested");
-};
+function buttonToneForAction(
+  action: DockActionItem,
+): "primary" | "secondary" | "surface" | "danger" | "outline" | "ghost" {
+  if (action.tone === "surface") return "surface";
+  if (action.tone === "secondary") return "secondary";
+  if (action.tone === "danger") return "danger";
+  return "primary";
+}
 </script>
 
 <style lang="scss" scoped>
@@ -1192,69 +1198,73 @@ const reimbursementReasonText = (
   color: var(--sys-color-on-secondary-container);
 }
 
-.section-card {
+.facts-card {
   margin-top: var(--sys-spacing-lg);
-  @include mx.pu-surface-card(section);
+}
+
+.contextual-area {
+  margin-top: var(--sys-spacing-lg);
   display: flex;
   flex-direction: column;
   gap: var(--sys-spacing-sm);
 }
 
-.section-title {
-  margin: 0;
-  @include mx.pu-font(title-medium);
-}
-
-.section-description {
-  margin: 0;
-  @include mx.pu-font(body-medium);
-  color: var(--sys-color-on-surface-variant);
-}
-
-.fit-empty {
-  @include mx.pu-font(body-small);
-  color: var(--sys-color-on-surface-variant);
-}
-
-.fit-overview {
-  margin: 0;
-  @include mx.pu-font(body-medium);
-}
-
-.roster-chip-overflow {
-  @include mx.pu-font(label-medium);
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-height: var(--sys-size-medium);
-  padding: var(--sys-spacing-xs) var(--sys-spacing-sm);
-  border-radius: 999px;
-  background: var(--sys-color-secondary-container);
-  color: var(--sys-color-on-secondary-container);
-}
-
-.booking-support-entry-card__header {
+.primary-action {
   display: flex;
-  justify-content: space-between;
-  align-items: center;
+  flex-direction: column;
   gap: var(--sys-spacing-sm);
 }
 
-.booking-support-entry-card__action {
-  @include mx.pu-font(label-medium);
-  color: var(--sys-color-primary);
-  text-decoration: none;
+.primary-action__button {
+  max-width: 100%;
 }
 
-.location-gallery-link {
-  @include mx.pu-font(label-medium);
-  border: none;
-  padding: 0;
-  color: var(--sys-color-primary);
-  background: transparent;
-  width: fit-content;
-  cursor: pointer;
-  text-decoration: underline;
+.utility-area {
+  margin-top: var(--sys-spacing-lg);
+  display: flex;
+  flex-direction: column;
+}
+
+.utility-row {
+  padding: var(--sys-spacing-med) 0;
+  border-top: 1px solid var(--sys-color-outline-variant);
+}
+
+.utility-row__main {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: var(--sys-spacing-sm);
+}
+
+.utility-row__content {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--sys-spacing-2xs);
+}
+
+.utility-row__content--stack {
+  gap: var(--sys-spacing-sm);
+}
+
+.utility-row__title {
+  margin: 0;
+  @include mx.pu-font(title-small);
+}
+
+.utility-row__description {
+  margin: 0;
+  @include mx.pu-font(body-medium);
+  color: var(--sys-color-on-surface-variant);
+}
+
+.utility-row__actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: var(--sys-spacing-xs);
+  flex-shrink: 0;
 }
 
 .action-btn {
@@ -1311,16 +1321,6 @@ const reimbursementReasonText = (
   margin-top: var(--sys-spacing-sm);
 }
 
-.released-notice {
-  background: var(--sys-color-error-container);
-  border-radius: 10px;
-}
-
-.released-notice__text {
-  margin: 0;
-  @include mx.pu-font(body-medium);
-  color: var(--sys-color-on-error-container);
-}
 .context-details {
   margin-top: var(--sys-spacing-lg);
 }
@@ -1328,6 +1328,26 @@ const reimbursementReasonText = (
 .context-summary {
   @include mx.pu-font(title-small);
   cursor: pointer;
+}
+
+.context-details__body {
+  margin-top: var(--sys-spacing-sm);
+  display: flex;
+  flex-direction: column;
+  gap: var(--sys-spacing-lg);
+}
+
+.context-section {
+  padding-top: var(--sys-spacing-sm);
+  border-top: 1px solid var(--sys-color-outline-variant);
+  display: flex;
+  flex-direction: column;
+  gap: var(--sys-spacing-sm);
+}
+
+.context-section__title {
+  margin: 0;
+  @include mx.pu-font(title-small);
 }
 
 .modal-text {
@@ -1374,6 +1394,15 @@ const reimbursementReasonText = (
   .header-quick-actions {
     flex-wrap: wrap;
     justify-content: flex-end;
+  }
+
+  .utility-row__main {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .utility-row__actions {
+    justify-content: flex-start;
   }
 }
 </style>


### PR DESCRIPTION
## Summary
- rework /apr/:id into one PR Facts card plus inline contextual actions and utilities
- convert recovery and awareness lanes into cardless rows and disclosures
- demote booking support, shares, reminders, and exit into lower utility sections while keeping existing flows

## Testing
- pnpm --filter @partner-up-dev/frontend build