### PR TITLE
Fix WeChat booking result notification flow

### DIFF
--- a/apps/backend/AGENTS.md
+++ b/apps/backend/AGENTS.md
@@ -106,7 +106,7 @@ Read following documents when needed and keep them current:
 - 确认机制（5.2）: 新增 `/api/pr/:id/confirm`；`T-1h` 自动释放未确认 `JOINED` 槽位，`T-1h~T-30min` 加入即自动确认，`T-30min` 后禁止 join。
 - 公众号提醒（5.2）: 新增 `GET/POST /api/wechat/reminders/subscription`；当前仅 Anchor PR 参与会调度 `confirm_start` 与 `confirm_end - 30min` 任务（优先服务号订阅通知 `message/subscribe/bizsend`，模板 ID 优先读取 `config` 表对应 key，缺失时再回退到同语义环境变量；模板消息通道保留兜底），退出/释放/关闭提醒会删除待执行任务，发送结果落库 `notification_deliveries`。
 - 预订执行控制台（Admin）: 新增 `GET /api/admin/booking-execution/workspace` 与 `POST /api/admin/anchor-prs/:id/booking-execution`；后端会基于 `READY/FULL/LOCKED_TO_START + 已达到最小活跃人数 + 平台代订资源` 推导待处理 Anchor PR，记录 append-only 的预订执行审计，并合并 `partner.admin_manual_release` 操作日志供管理端查询。
-- 场地预订结果通知: `BOOKING_RESULT` 现已接入真实发送链路；管理员提交预订结果后，会向同 PR 所有活跃参与者按剩余次数发送服务号订阅通知，成功后消费一次 credit，若返回 `43101` 则自动清零该用户该通知项次数。
+- 场地预订结果通知: `BOOKING_RESULT` 通过 JobRunner 异步发送；管理员提交预订结果后，会为该执行记录创建发送任务，向同 PR 的活跃参与者按剩余次数发送服务号订阅通知，并将逐用户结果落库到 `notification_deliveries`。成功后消费一次 credit，若返回 `43101` 则自动清零该用户该通知项次数。
 - 签到回流（5.3）: 新增 `/api/pr/:id/check-in`，记录 `didAttend` / `wouldJoinAgain`，到场时槽位置为 `ATTENDED`。
 - 分享能力: 提供小红书文案/海报与微信缩略图生成能力，并支持缓存到后端。
 - 公共配置能力: 提供 `/api/config/public/:key` 只读配置查询（当前支持 `author_wechat_qr_code`、`wecom_staff_link`、`wecom_service_qr_code`、`wecom_support_link_wechat_in`、`wecom_support_link_wechat_out`、`wechat_official_account_qr_code`）。

--- a/apps/backend/drizzle/0013_notification_delivery_generalization.sql
+++ b/apps/backend/drizzle/0013_notification_delivery_generalization.sql
@@ -1,0 +1,21 @@
+alter table "notification_deliveries"
+  add column if not exists "notification_kind" text;
+
+alter table "notification_deliveries"
+  add column if not exists "notification_trigger" text;
+
+update "notification_deliveries"
+set
+  "notification_kind" = 'REMINDER_CONFIRMATION',
+  "notification_trigger" = case
+    when "reminder_type" = 'T_MINUS_24H' then 'CONFIRM_START'
+    when "reminder_type" = 'T_MINUS_2H' then 'CONFIRM_END_MINUS_30M'
+    else null
+  end
+where "notification_kind" is null;
+
+alter table "notification_deliveries"
+  alter column "notification_kind" set not null;
+
+alter table "notification_deliveries"
+  drop column "reminder_type";

--- a/apps/backend/src/domains/admin-booking-execution/services/send-booking-result-notifications.ts
+++ b/apps/backend/src/domains/admin-booking-execution/services/send-booking-result-notifications.ts
@@ -1,159 +1,126 @@
-import type { PRId } from "../../../entities";
-import type { UserId } from "../../../entities/user";
-import { env } from "../../../lib/env";
+import type {
+  AnchorPRBookingExecution,
+  AnchorPRBookingExecutionResult,
+  PRId,
+} from "../../../entities";
 import { PartnerRepository } from "../../../repositories/PartnerRepository";
-import { UserNotificationOptRepository } from "../../../repositories/UserNotificationOptRepository";
-import { UserRepository } from "../../../repositories/UserRepository";
 import {
-  WeChatSubscriptionMessageError,
-  WeChatSubscriptionMessageService,
-  type SendBookingResultNotificationParams,
-} from "../../../services/WeChatSubscriptionMessageService";
+  resolveBookingResultStatusLabel,
+  scheduleWeChatBookingResultNotifications,
+  type BookingResultNotificationSummary,
+} from "../../../infra/notifications";
+import type { UserId } from "../../../entities/user";
 
 const partnerRepo = new PartnerRepository();
-const userRepo = new UserRepository();
-const userNotificationOptRepo = new UserNotificationOptRepository();
-const subscriptionMessageService = new WeChatSubscriptionMessageService();
 
-export type BookingResultNotificationSummary = {
-  targetCount: number;
-  successCount: number;
-  failureCount: number;
-  skippedCount: number;
+const ISO_DATE_ONLY_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+const normalizeText = (value: string | null | undefined): string | null => {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : null;
 };
 
-const resolvePrUrl = (prId: PRId): string | null => {
-  const frontendUrl = env.FRONTEND_URL?.trim();
-  if (!frontendUrl) return null;
-
-  try {
-    const url = new URL(frontendUrl);
-    url.pathname = `/apr/${prId}`;
-    url.search = "";
-    url.hash = "";
-    return url.toString();
-  } catch {
-    return null;
+const formatDateTime = (value: string): string => {
+  if (ISO_DATE_ONLY_RE.test(value)) {
+    return value;
   }
+
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    return value;
+  }
+
+  return new Intl.DateTimeFormat("zh-CN", {
+    timeZone: "Asia/Shanghai",
+    hour12: false,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+  }).format(parsed);
 };
 
-const buildParams = (input: {
-  prId: PRId;
-  prTitle: string;
-  resourceTitle: string;
-  result: "SUCCESS" | "FAILED";
+const formatActivityTime = (
+  timeWindow: [string | null, string | null],
+): string => {
+  const [startRaw, endRaw] = timeWindow;
+  const start = normalizeText(startRaw);
+  const end = normalizeText(endRaw);
+  if (start && end) {
+    return `${formatDateTime(start)} - ${formatDateTime(end)}`;
+  }
+  if (start) {
+    return formatDateTime(start);
+  }
+  if (end) {
+    return formatDateTime(end);
+  }
+  return "时间待定";
+};
+
+const resolveBookingDetail = (input: {
+  result: AnchorPRBookingExecutionResult;
   reason: string | null;
-  openId: string;
-}): SendBookingResultNotificationParams => ({
-  openId: input.openId,
-  activityTitle: input.prTitle,
-  resourceTitle: input.resourceTitle,
-  resultLabel: input.result === "SUCCESS" ? "预订成功" : "预订失败",
-  remark:
-    input.reason?.trim() ||
-    (input.result === "SUCCESS"
-      ? "平台已完成预订，请留意后续安排"
-      : "平台暂未完成预订，请留意后续安排"),
-  page: resolvePrUrl(input.prId),
-});
+  resourceSummaryText: string;
+  resourceDetailRules: string[];
+}): string => {
+  const preferred =
+    normalizeText(input.reason) ??
+    normalizeText(input.resourceSummaryText) ??
+    input.resourceDetailRules.map((item) => normalizeText(item)).find(Boolean) ??
+    null;
 
-const classifyBookingResultError = (
-  error: unknown,
-): { code: string | null; message: string } => {
-  if (error instanceof WeChatSubscriptionMessageError) {
-    return {
-      code: error.errorCode,
-      message: error.message,
-    };
+  if (preferred) {
+    return preferred;
   }
 
-  if (error instanceof Error) {
-    return {
-      code: null,
-      message: error.message,
-    };
-  }
-
-  return {
-    code: null,
-    message: String(error),
-  };
+  return input.result === "SUCCESS"
+    ? "平台已完成预订"
+    : "平台暂未完成预订";
 };
+
+export type { BookingResultNotificationSummary };
 
 export async function sendBookingResultNotifications(input: {
+  executionId: AnchorPRBookingExecution["id"];
   prId: PRId;
-  prTitle: string;
+  prTimeWindow: [string | null, string | null];
+  location: string | null;
   resourceTitle: string;
-  result: "SUCCESS" | "FAILED";
+  resourceSummaryText: string;
+  resourceDetailRules: string[];
+  result: AnchorPRBookingExecutionResult;
   reason: string | null;
 }): Promise<BookingResultNotificationSummary> {
   const activeParticipants =
     await partnerRepo.listActiveParticipantSummariesByPrId(input.prId);
   const recipientUserIds = Array.from(
-    new Set(activeParticipants.map((participant) => participant.userId)),
+    new Set<UserId>(activeParticipants.map((participant) => participant.userId)),
   );
 
-  const summary: BookingResultNotificationSummary = {
-    targetCount: recipientUserIds.length,
-    successCount: 0,
-    failureCount: 0,
-    skippedCount: 0,
-  };
-
   if (recipientUserIds.length === 0) {
-    return summary;
+    return {
+      targetCount: 0,
+      successCount: 0,
+      failureCount: 0,
+      skippedCount: 0,
+    };
   }
 
-  const configured = await subscriptionMessageService.isBookingResultConfigured();
-  if (!configured) {
-    summary.failureCount = recipientUserIds.length;
-    return summary;
-  }
-
-  for (const recipientUserId of recipientUserIds) {
-    const user = await userRepo.findById(recipientUserId as UserId);
-    if (!user || user.status !== "ACTIVE" || !user.openId) {
-      summary.skippedCount += 1;
-      continue;
-    }
-
-    const notificationOpt = await userNotificationOptRepo.findByUserId(user.id);
-    const snapshot = userNotificationOptRepo.getSubscriptionSnapshot(
-      notificationOpt,
-      "BOOKING_RESULT",
-    );
-    if (!snapshot.enabled) {
-      summary.skippedCount += 1;
-      continue;
-    }
-
-    try {
-      await subscriptionMessageService.sendBookingResultNotification(
-        buildParams({
-          prId: input.prId,
-          prTitle: input.prTitle,
-          resourceTitle: input.resourceTitle,
-          result: input.result,
-          reason: input.reason,
-          openId: user.openId,
-        }),
-      );
-      summary.successCount += 1;
-      await userNotificationOptRepo.consumeOneWechatNotificationCredit(
-        user.id,
-        "BOOKING_RESULT",
-      );
-    } catch (error) {
-      const classified = classifyBookingResultError(error);
-      if (classified.code === "43101") {
-        await userNotificationOptRepo.clearWechatNotificationCredits(
-          user.id,
-          "BOOKING_RESULT",
-        );
-      }
-      summary.failureCount += 1;
-    }
-  }
-
-  return summary;
+  return scheduleWeChatBookingResultNotifications({
+    executionId: input.executionId,
+    prId: input.prId,
+    recipientUserIds,
+    bookingItem: input.resourceTitle,
+    statusLabel: resolveBookingResultStatusLabel(input.result),
+    activityTime: formatActivityTime(input.prTimeWindow),
+    address: normalizeText(input.location) ?? "地点待定",
+    bookingDetail: resolveBookingDetail({
+      result: input.result,
+      reason: input.reason,
+      resourceSummaryText: input.resourceSummaryText,
+      resourceDetailRules: input.resourceDetailRules,
+    }),
+  });
 }

--- a/apps/backend/src/domains/admin-booking-execution/use-cases/submit-admin-anchor-pr-booking-execution.ts
+++ b/apps/backend/src/domains/admin-booking-execution/use-cases/submit-admin-anchor-pr-booking-execution.ts
@@ -66,14 +66,6 @@ export async function submitAdminAnchorPRBookingExecution(input: {
     });
   }
 
-  const notificationSummary = await sendBookingResultNotifications({
-    prId: input.prId,
-    prTitle:
-      record.root.title?.trim() || record.root.type || `活动 #${record.root.id}`,
-    resourceTitle: targetResource.title,
-    result: input.result,
-    reason: normalizedReason,
-  });
   const bookingContact = await bookingContactRepo.findByPrId(input.prId);
 
   const createdExecution = await bookingExecutionRepo.create({
@@ -84,16 +76,39 @@ export async function submitAdminAnchorPRBookingExecution(input: {
     actorUserId: input.actorUserId,
     result: input.result,
     reason: normalizedReason,
-    notificationTargetCount: notificationSummary.targetCount,
-    notificationSuccessCount: notificationSummary.successCount,
-    notificationFailureCount: notificationSummary.failureCount,
-    notificationSkippedCount: notificationSummary.skippedCount,
+    notificationTargetCount: 0,
+    notificationSuccessCount: 0,
+    notificationFailureCount: 0,
+    notificationSkippedCount: 0,
   });
 
   if (!createdExecution) {
     throw new HTTPException(500, {
       message: "Failed to record booking execution",
     });
+  }
+
+  let notificationSummary: BookingResultNotificationSummary;
+  try {
+    notificationSummary = await sendBookingResultNotifications({
+      executionId: createdExecution.id,
+      prId: input.prId,
+      prTimeWindow: record.root.time,
+      location: record.root.location,
+      resourceTitle: targetResource.title,
+      resourceSummaryText: targetResource.summaryText,
+      resourceDetailRules: [...targetResource.detailRules],
+      result: input.result,
+      reason: normalizedReason,
+    });
+
+    await bookingExecutionRepo.updateNotificationSummary(
+      createdExecution.id,
+      notificationSummary,
+    );
+  } catch (error) {
+    await bookingExecutionRepo.deleteById(createdExecution.id);
+    throw error;
   }
 
   operationLogService.log({

--- a/apps/backend/src/entities/notification-delivery.ts
+++ b/apps/backend/src/entities/notification-delivery.ts
@@ -11,10 +11,16 @@ import { createInsertSchema, createSelectSchema } from "drizzle-zod";
 import { z } from "zod";
 import { jobs } from "./job";
 import { partnerRequests, type PRId } from "./partner-request";
+import type { WeChatNotificationKind } from "./user-notification-opt";
 import { users, type UserId } from "./user";
 
-export const reminderTypeSchema = z.enum(["T_MINUS_24H", "T_MINUS_2H"]);
-export type ReminderType = z.infer<typeof reminderTypeSchema>;
+export const confirmationReminderTriggerSchema = z.enum([
+  "CONFIRM_START",
+  "CONFIRM_END_MINUS_30M",
+]);
+export type ConfirmationReminderTrigger = z.infer<
+  typeof confirmationReminderTriggerSchema
+>;
 
 export const notificationDeliveryResultSchema = z.enum([
   "SUCCESS",
@@ -40,7 +46,12 @@ export const notificationDeliveries = pgTable(
       .$type<UserId>()
       .notNull()
       .references(() => users.id, { onDelete: "cascade" }),
-    reminderType: text("reminder_type").$type<ReminderType>().notNull(),
+    notificationKind: text("notification_kind")
+      .$type<WeChatNotificationKind>()
+      .notNull(),
+    notificationTrigger: text("notification_trigger").$type<
+      ConfirmationReminderTrigger | null
+    >(),
     scheduledAt: timestamp("scheduled_at").notNull(),
     sentAt: timestamp("sent_at"),
     result: text("result")

--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -34,6 +34,7 @@ import {
 } from "./infra/analytics";
 import { processOutboxBatch } from "./infra/events";
 import {
+  registerWeChatBookingResultJobs,
   registerWeChatNewPartnerJobs,
   registerWeChatReminderJobs,
 } from "./infra/notifications";
@@ -43,6 +44,7 @@ import { withTimeout } from "./lib/with-timeout";
 const app = new Hono();
 registerWeChatReminderJobs();
 registerWeChatNewPartnerJobs();
+registerWeChatBookingResultJobs();
 registerAnalyticsAggregationJobs();
 void bootstrapAnalyticsAggregationJobs().catch((error) => {
   console.error(

--- a/apps/backend/src/infra/notifications/index.ts
+++ b/apps/backend/src/infra/notifications/index.ts
@@ -1,4 +1,10 @@
 export {
+  registerWeChatBookingResultJobs,
+  scheduleWeChatBookingResultNotifications,
+  resolveBookingResultStatusLabel,
+} from "./wechat-booking-result";
+
+export {
   registerWeChatReminderJobs,
   scheduleWeChatReminderJobsForParticipant,
   cancelWeChatReminderJobsForParticipant,

--- a/apps/backend/src/infra/notifications/wechat-booking-result.ts
+++ b/apps/backend/src/infra/notifications/wechat-booking-result.ts
@@ -1,0 +1,308 @@
+import { z } from "zod";
+import type {
+  AnchorPRBookingExecution,
+  AnchorPRBookingExecutionResult,
+  PRId,
+} from "../../entities";
+import { userIdSchema, type UserId } from "../../entities/user";
+import { env } from "../../lib/env";
+import { AnchorPRBookingExecutionRepository } from "../../repositories/AnchorPRBookingExecutionRepository";
+import { NotificationDeliveryRepository } from "../../repositories/NotificationDeliveryRepository";
+import { UserNotificationOptRepository } from "../../repositories/UserNotificationOptRepository";
+import { UserRepository } from "../../repositories/UserRepository";
+import {
+  WeChatSubscriptionMessageError,
+  WeChatSubscriptionMessageService,
+} from "../../services/WeChatSubscriptionMessageService";
+import { jobRunner, NO_LATE_TOLERANCE_MS, type JobHandlerContext } from "../jobs";
+
+const WECHAT_BOOKING_RESULT_JOB_TYPE = "wechat.notification.booking-result";
+
+const bookingResultJobPayloadSchema = z.object({
+  executionId: z.coerce.number().int().positive(),
+  prId: z.coerce.number().int().positive(),
+  recipientUserIds: z.array(userIdSchema),
+  bookingItem: z.string().trim().min(1),
+  statusLabel: z.string().trim().min(1),
+  activityTime: z.string().trim().min(1),
+  address: z.string().trim().min(1),
+  bookingDetail: z.string().trim().min(1),
+  scheduledAtIso: z.string().datetime(),
+});
+
+type BookingResultJobPayload = z.infer<typeof bookingResultJobPayloadSchema>;
+
+export type BookingResultNotificationSummary = {
+  targetCount: number;
+  successCount: number;
+  failureCount: number;
+  skippedCount: number;
+};
+
+const bookingExecutionRepo = new AnchorPRBookingExecutionRepository();
+const userRepo = new UserRepository();
+const userNotificationOptRepo = new UserNotificationOptRepository();
+const deliveryRepo = new NotificationDeliveryRepository();
+const subscriptionMessageService = new WeChatSubscriptionMessageService();
+
+let bookingResultHandlerRegistered = false;
+
+const buildBookingResultDedupeKey = (
+  executionId: AnchorPRBookingExecution["id"],
+): string => `wechat-booking-result:${executionId}`;
+
+const createEmptySummary = (targetCount: number): BookingResultNotificationSummary => ({
+  targetCount,
+  successCount: 0,
+  failureCount: 0,
+  skippedCount: 0,
+});
+
+const resolvePrUrl = (prId: PRId): string | null => {
+  const frontendUrl = env.FRONTEND_URL?.trim();
+  if (!frontendUrl) return null;
+
+  try {
+    const url = new URL(frontendUrl);
+    url.pathname = `/apr/${prId}`;
+    url.search = "";
+    url.hash = "";
+    return url.toString();
+  } catch {
+    return null;
+  }
+};
+
+const classifyBookingResultError = (
+  error: unknown,
+): { code: string | null; message: string } => {
+  if (error instanceof WeChatSubscriptionMessageError) {
+    return {
+      code: error.errorCode,
+      message: error.message,
+    };
+  }
+
+  if (error instanceof Error) {
+    return {
+      code: null,
+      message: error.message,
+    };
+  }
+
+  return {
+    code: null,
+    message: String(error),
+  };
+};
+
+const persistSummary = async (
+  executionId: AnchorPRBookingExecution["id"],
+  summary: BookingResultNotificationSummary,
+): Promise<void> => {
+  const updated = await bookingExecutionRepo.updateNotificationSummary(
+    executionId,
+    summary,
+  );
+  if (!updated) {
+    throw new Error("Booking execution record not found while updating summary");
+  }
+};
+
+const recordDelivery = async (input: {
+  jobId: number;
+  payload: BookingResultJobPayload;
+  userId: UserId;
+  result: "SUCCESS" | "FAILED" | "SKIPPED";
+  errorCode?: string | null;
+  errorMessage?: string | null;
+}): Promise<void> => {
+  await deliveryRepo.create({
+    jobId: input.jobId,
+    prId: input.payload.prId,
+    userId: input.userId,
+    notificationKind: "BOOKING_RESULT",
+    notificationTrigger: null,
+    scheduledAt: new Date(input.payload.scheduledAtIso),
+    sentAt: new Date(),
+    result: input.result,
+    errorCode: input.errorCode ?? null,
+    errorMessage: input.errorMessage ?? null,
+  });
+};
+
+async function handleBookingResultJob(
+  payloadRaw: Record<string, unknown>,
+  context: JobHandlerContext,
+): Promise<void> {
+  const parseResult = bookingResultJobPayloadSchema.safeParse(payloadRaw);
+  if (!parseResult.success) {
+    throw new Error("Invalid booking result notification job payload");
+  }
+  const payload = parseResult.data;
+
+  const recipientUserIds = Array.from(new Set(payload.recipientUserIds));
+  const summary = createEmptySummary(recipientUserIds.length);
+
+  if (recipientUserIds.length === 0) {
+    await persistSummary(payload.executionId, summary);
+    return;
+  }
+
+  const configured = await subscriptionMessageService.isBookingResultConfigured();
+  if (!configured) {
+    summary.failureCount = recipientUserIds.length;
+    for (const userId of recipientUserIds) {
+      await recordDelivery({
+        jobId: context.jobId,
+        payload,
+        userId,
+        result: "FAILED",
+        errorCode: "BOOKING_RESULT_CHANNEL_NOT_CONFIGURED",
+        errorMessage: "Booking result subscription message channel is not configured",
+      });
+    }
+    await persistSummary(payload.executionId, summary);
+    return;
+  }
+
+  for (const userId of recipientUserIds) {
+    const user = await userRepo.findById(userId);
+    if (!user || user.status !== "ACTIVE") {
+      summary.skippedCount += 1;
+      await recordDelivery({
+        jobId: context.jobId,
+        payload,
+        userId,
+        result: "SKIPPED",
+        errorCode: "USER_INACTIVE_OR_MISSING",
+        errorMessage: "User is missing or not active",
+      });
+      continue;
+    }
+
+    if (!user.openId) {
+      summary.skippedCount += 1;
+      await recordDelivery({
+        jobId: context.jobId,
+        payload,
+        userId,
+        result: "SKIPPED",
+        errorCode: "USER_OPENID_MISSING",
+        errorMessage: "User has no bound WeChat openId",
+      });
+      continue;
+    }
+
+    const notificationOpt = await userNotificationOptRepo.findByUserId(user.id);
+    const snapshot = userNotificationOptRepo.getSubscriptionSnapshot(
+      notificationOpt,
+      "BOOKING_RESULT",
+    );
+    if (!snapshot.enabled) {
+      summary.skippedCount += 1;
+      await recordDelivery({
+        jobId: context.jobId,
+        payload,
+        userId,
+        result: "SKIPPED",
+        errorCode: "BOOKING_RESULT_OPT_OUT",
+        errorMessage: "User disabled booking result notifications",
+      });
+      continue;
+    }
+
+    try {
+      await subscriptionMessageService.sendBookingResultNotification({
+        openId: user.openId,
+        bookingItem: payload.bookingItem,
+        statusLabel: payload.statusLabel,
+        activityTime: payload.activityTime,
+        address: payload.address,
+        bookingDetail: payload.bookingDetail,
+        page: resolvePrUrl(payload.prId),
+      });
+      summary.successCount += 1;
+      await recordDelivery({
+        jobId: context.jobId,
+        payload,
+        userId,
+        result: "SUCCESS",
+      });
+      await userNotificationOptRepo.consumeOneWechatNotificationCredit(
+        user.id,
+        "BOOKING_RESULT",
+      );
+    } catch (error) {
+      const classified = classifyBookingResultError(error);
+      if (classified.code === "43101") {
+        await userNotificationOptRepo.clearWechatNotificationCredits(
+          user.id,
+          "BOOKING_RESULT",
+        );
+      }
+
+      summary.failureCount += 1;
+      await recordDelivery({
+        jobId: context.jobId,
+        payload,
+        userId,
+        result: "FAILED",
+        errorCode: classified.code,
+        errorMessage: classified.message,
+      });
+    }
+  }
+
+  await persistSummary(payload.executionId, summary);
+}
+
+export function registerWeChatBookingResultJobs(): void {
+  if (bookingResultHandlerRegistered) {
+    return;
+  }
+  jobRunner.registerHandler(
+    WECHAT_BOOKING_RESULT_JOB_TYPE,
+    handleBookingResultJob,
+  );
+  bookingResultHandlerRegistered = true;
+}
+
+export async function scheduleWeChatBookingResultNotifications(input: {
+  executionId: AnchorPRBookingExecution["id"];
+  prId: PRId;
+  recipientUserIds: UserId[];
+  bookingItem: string;
+  statusLabel: string;
+  activityTime: string;
+  address: string;
+  bookingDetail: string;
+}): Promise<BookingResultNotificationSummary> {
+  const scheduledAt = new Date();
+  const recipientUserIds = Array.from(new Set(input.recipientUserIds));
+  const summary = createEmptySummary(recipientUserIds.length);
+
+  await jobRunner.scheduleOnce({
+    jobType: WECHAT_BOOKING_RESULT_JOB_TYPE,
+    runAt: scheduledAt,
+    lateToleranceMs: NO_LATE_TOLERANCE_MS,
+    dedupeKey: buildBookingResultDedupeKey(input.executionId),
+    payload: {
+      executionId: input.executionId,
+      prId: input.prId,
+      recipientUserIds,
+      bookingItem: input.bookingItem,
+      statusLabel: input.statusLabel,
+      activityTime: input.activityTime,
+      address: input.address,
+      bookingDetail: input.bookingDetail,
+      scheduledAtIso: scheduledAt.toISOString(),
+    },
+  });
+
+  return summary;
+}
+
+export const resolveBookingResultStatusLabel = (
+  result: AnchorPRBookingExecutionResult,
+): string => (result === "SUCCESS" ? "预订成功" : "预订失败");

--- a/apps/backend/src/infra/notifications/wechat-reminder.ts
+++ b/apps/backend/src/infra/notifications/wechat-reminder.ts
@@ -2,8 +2,8 @@ import { z } from "zod";
 import type { PartnerId } from "../../entities/partner";
 import type { PRId, PartnerRequest } from "../../entities/partner-request";
 import {
-  reminderTypeSchema,
-  type ReminderType,
+  confirmationReminderTriggerSchema,
+  type ConfirmationReminderTrigger,
 } from "../../entities/notification-delivery";
 import { userIdSchema, type UserId } from "../../entities/user";
 import { PartnerRepository } from "../../repositories/PartnerRepository";
@@ -27,16 +27,20 @@ import { env } from "../../lib/env";
 
 const WECHAT_REMINDER_JOB_TYPE = "wechat.reminder.confirmation";
 const REMINDER_DEDUPE_PREFIX = "wechat-reminder";
-const REMINDER_TYPES: readonly ReminderType[] = ["T_MINUS_24H", "T_MINUS_2H"];
 const CONFIRMATION_END_REMINDER_LEAD_MS = 30 * 60 * 1000;
 const WECHAT_NEW_PARTNER_JOB_TYPE = "wechat.notification.new-partner";
 const NEW_PARTNER_DEDUPE_PREFIX = "wechat-new-partner";
 const NEW_PARTNER_TIP = "有新搭子加入请及时确认";
 
+const CONFIRMATION_REMINDER_TRIGGERS: readonly ConfirmationReminderTrigger[] = [
+  "CONFIRM_START",
+  "CONFIRM_END_MINUS_30M",
+];
+
 const reminderJobPayloadSchema = z.object({
   prId: z.coerce.number().int().positive(),
   userId: userIdSchema,
-  reminderType: reminderTypeSchema,
+  trigger: confirmationReminderTriggerSchema,
   scheduledAtIso: z.string().datetime(),
 });
 
@@ -67,8 +71,9 @@ let newPartnerHandlerRegistered = false;
 const buildReminderDedupeKey = (
   prId: PRId,
   userId: UserId,
-  reminderType: ReminderType,
-): string => `${REMINDER_DEDUPE_PREFIX}:${userId}:${prId}:${reminderType}`;
+  trigger: ConfirmationReminderTrigger,
+): string =>
+  `${REMINDER_DEDUPE_PREFIX}:${userId}:${prId}:${trigger}`;
 
 const buildReminderDedupePrefixForUser = (userId: UserId): string =>
   `${REMINDER_DEDUPE_PREFIX}:${userId}:`;
@@ -88,9 +93,9 @@ const getReminderRunAt = (
     ReturnType<typeof resolveAnchorParticipationPolicy>,
     "confirmationStartAt" | "confirmationEndAt"
   >,
-  reminderType: ReminderType,
+  trigger: ConfirmationReminderTrigger,
 ): Date | null => {
-  if (reminderType === "T_MINUS_24H") {
+  if (trigger === "CONFIRM_START") {
     return policy.confirmationStartAt;
   }
 
@@ -155,7 +160,8 @@ const recordDelivery = async (input: {
     jobId: input.jobId,
     prId: input.payload.prId,
     userId: input.payload.userId,
-    reminderType: input.payload.reminderType,
+    notificationKind: "REMINDER_CONFIRMATION",
+    notificationTrigger: input.payload.trigger,
     scheduledAt: new Date(input.payload.scheduledAtIso),
     sentAt: new Date(),
     result: input.result,
@@ -193,8 +199,8 @@ const resolveReminderOrderNo = (
   userId: UserId,
 ): string => `PR-${request.id}-${userId.slice(-6)}`;
 
-const resolveReminderRemark = (reminderType: ReminderType): string =>
-  reminderType === "T_MINUS_24H"
+const resolveReminderRemark = (trigger: ConfirmationReminderTrigger): string =>
+  trigger === "CONFIRM_START"
     ? "确认开启提醒"
     : "确认截止前30分钟提醒";
 
@@ -347,13 +353,13 @@ async function handleReminderJob(
         orderContent: resolveReminderTitle(request),
         orderNo: resolveReminderOrderNo(request, user.id),
         appointmentAt: formatReminderDateField(startAt),
-        remark: resolveReminderRemark(payload.reminderType),
+        remark: resolveReminderRemark(payload.trigger),
         page: prPage,
       });
     } else {
       await templateService.sendReminderTemplate({
         openId: user.openId,
-        reminderType: payload.reminderType,
+        trigger: payload.trigger,
         title: resolveReminderTitle(request),
         startAtLabel: formatReminderTimeLabel(startAt),
         location: request.location,
@@ -430,8 +436,8 @@ export async function scheduleWeChatReminderJobsForParticipant(
     return;
   }
 
-  for (const reminderType of REMINDER_TYPES) {
-    const runAt = getReminderRunAt(policy, reminderType);
+  for (const trigger of CONFIRMATION_REMINDER_TRIGGERS) {
+    const runAt = getReminderRunAt(policy, trigger);
     if (!runAt || runAt.getTime() <= Date.now()) {
       continue;
     }
@@ -440,11 +446,11 @@ export async function scheduleWeChatReminderJobsForParticipant(
       jobType: WECHAT_REMINDER_JOB_TYPE,
       runAt,
       lateToleranceMs: NO_LATE_TOLERANCE_MS,
-      dedupeKey: buildReminderDedupeKey(request.id, userId, reminderType),
+      dedupeKey: buildReminderDedupeKey(request.id, userId, trigger),
       payload: {
         prId: request.id,
         userId,
-        reminderType,
+        trigger,
         scheduledAtIso: runAt.toISOString(),
       },
     });
@@ -456,10 +462,10 @@ export async function cancelWeChatReminderJobsForParticipant(
   userId: UserId,
 ): Promise<number> {
   let deleted = 0;
-  for (const reminderType of REMINDER_TYPES) {
+  for (const trigger of CONFIRMATION_REMINDER_TRIGGERS) {
     deleted += await jobRunner.deletePendingJobsByDedupe({
       jobType: WECHAT_REMINDER_JOB_TYPE,
-      dedupeKey: buildReminderDedupeKey(prId, userId, reminderType),
+      dedupeKey: buildReminderDedupeKey(prId, userId, trigger),
     });
   }
   return deleted;

--- a/apps/backend/src/repositories/AnchorPRBookingExecutionRepository.ts
+++ b/apps/backend/src/repositories/AnchorPRBookingExecutionRepository.ts
@@ -27,6 +27,34 @@ export class AnchorPRBookingExecutionRepository {
     return result[0] ?? null;
   }
 
+  async deleteById(id: AnchorPRBookingExecution["id"]): Promise<void> {
+    await db
+      .delete(anchorPRBookingExecutions)
+      .where(eq(anchorPRBookingExecutions.id, id));
+  }
+
+  async updateNotificationSummary(
+    id: AnchorPRBookingExecution["id"],
+    summary: {
+      targetCount: number;
+      successCount: number;
+      failureCount: number;
+      skippedCount: number;
+    },
+  ): Promise<AnchorPRBookingExecution | null> {
+    const result = await db
+      .update(anchorPRBookingExecutions)
+      .set({
+        notificationTargetCount: summary.targetCount,
+        notificationSuccessCount: summary.successCount,
+        notificationFailureCount: summary.failureCount,
+        notificationSkippedCount: summary.skippedCount,
+      })
+      .where(eq(anchorPRBookingExecutions.id, id))
+      .returning();
+    return result[0] ?? null;
+  }
+
   async listAll(): Promise<AnchorPRBookingExecution[]> {
     return db
       .select()

--- a/apps/backend/src/services/WeChatSubscriptionMessageService.ts
+++ b/apps/backend/src/services/WeChatSubscriptionMessageService.ts
@@ -94,10 +94,11 @@ export interface SendNewPartnerNotificationParams {
 
 export interface SendBookingResultNotificationParams {
   openId: string;
-  activityTitle: string;
-  resourceTitle: string;
-  resultLabel: string;
-  remark: string;
+  bookingItem: string;
+  statusLabel: string;
+  activityTime: string;
+  address: string;
+  bookingDetail: string;
   page: string | null;
 }
 
@@ -289,10 +290,11 @@ export class WeChatSubscriptionMessageService {
       openId: params.openId,
       page: params.page,
       data: {
-        thing1: { value: clipText(params.activityTitle, 20) },
-        thing2: { value: clipText(params.resourceTitle, 20) },
-        thing3: { value: clipText(params.resultLabel, 20) },
-        thing4: { value: clipText(params.remark, 20) },
+        thing2: { value: clipText(params.bookingItem, 20) },
+        phrase33: { value: clipText(params.statusLabel, 20) },
+        time24: { value: clipText(params.activityTime, 32) },
+        thing35: { value: clipText(params.address, 20) },
+        thing8: { value: clipText(params.bookingDetail, 20) },
       },
     });
   }

--- a/apps/backend/src/services/WeChatTemplateMessageService.ts
+++ b/apps/backend/src/services/WeChatTemplateMessageService.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import { env } from "../lib/env";
 import { proxyFetch } from "../lib/proxy-fetch";
-import type { ReminderType } from "../entities/notification-delivery";
+import type { ConfirmationReminderTrigger } from "../entities/notification-delivery";
 
 type OfficialAccountConfig = {
   appId: string;
@@ -43,7 +43,7 @@ let accessTokenCache: TokenCache | null = null;
 
 export interface SendReminderTemplateParams {
   openId: string;
-  reminderType: ReminderType;
+  trigger: ConfirmationReminderTrigger;
   title: string;
   startAtLabel: string;
   location: string | null;
@@ -121,7 +121,7 @@ export class WeChatTemplateMessageService {
     url.searchParams.set("access_token", accessToken);
 
     const reminderLabel =
-      params.reminderType === "T_MINUS_24H"
+      params.trigger === "CONFIRM_START"
         ? "确认开启提醒"
         : "确认截止前 30 分钟提醒";
 


### PR DESCRIPTION
## Summary
- move admin booking-result notifications onto a real JobRunner task and record per-user delivery outcomes
- send the correct WeChat booking-result submsg fields (`thing2`, `phrase33`, `time24`, `thing35`, `thing8`)
- remove legacy reminder payload compatibility and replace `T_MINUS_*` runtime naming with explicit confirmation triggers

## Root Cause
- admin booking execution sent booking-result notifications inline, so no booking-result job was ever created in `jobs`
- the booking-result sender used the wrong WeChat field keys
- the notification delivery model was still reminder-only, and confirmation reminder jobs still exposed legacy `T_MINUS_2H` naming even though the actual timing was `confirm_end - 30min`

## Testing
- `git diff --check`
- `pnpm --filter @partner-up-dev/backend build` could not run in this worktree because `node_modules` is missing and `tsup` is unavailable
