### PR TITLE
Limit WeChat auto login to Anchor PR detail

### DIFF
--- a/apps/backend/src/services/WeChatOAuthService.ts
+++ b/apps/backend/src/services/WeChatOAuthService.ts
@@ -97,6 +97,9 @@ export class WeChatOAuthService {
     authorizeUrl.searchParams.set("appid", appId);
     authorizeUrl.searchParams.set("redirect_uri", callbackUrl);
     authorizeUrl.searchParams.set("response_type", "code");
+    // Proactive auth is intentionally limited to Anchor PR detail and relies on
+    // WeChat-native snsapi_userinfo handling for non-user-initiated redirects.
+    // Keep forcePopup unset unless product explicitly wants forced consent UX.
     authorizeUrl.searchParams.set("scope", "snsapi_userinfo");
     authorizeUrl.searchParams.set("state", state);
 

--- a/apps/frontend/src/app/router.ts
+++ b/apps/frontend/src/app/router.ts
@@ -73,6 +73,7 @@ const routes: RouteRecordRaw[] = [
     component: AnchorPRPage,
     meta: {
       wechatSharePolicy: "skip",
+      wechatAutoLoginPolicy: "route",
     },
   },
   {
@@ -81,6 +82,7 @@ const routes: RouteRecordRaw[] = [
     component: UserProfilePage,
     meta: {
       wechatSharePolicy: "skip",
+      wechatAutoLoginPolicy: "skip",
     },
   },
   {
@@ -89,6 +91,7 @@ const routes: RouteRecordRaw[] = [
     component: AnchorPRBookingSupportPage,
     meta: {
       wechatSharePolicy: "skip",
+      wechatAutoLoginPolicy: "skip",
     },
   },
   {
@@ -181,6 +184,7 @@ const routes: RouteRecordRaw[] = [
     component: AnchorEventPage,
     meta: {
       wechatSharePolicy: "skip",
+      wechatAutoLoginPolicy: "skip",
     },
   },
   {

--- a/apps/frontend/src/processes/wechat/useRouteWeChatAutoLogin.ts
+++ b/apps/frontend/src/processes/wechat/useRouteWeChatAutoLogin.ts
@@ -4,12 +4,6 @@ import { useUserSessionStore } from "@/shared/auth/useUserSessionStore";
 import { isWeChatAbilityEnv } from "@/shared/wechat/ability-mocking";
 import { redirectToWeChatOAuthLogin } from "@/processes/wechat/oauth-login";
 
-const AUTO_LOGIN_ROUTE_NAMES = new Set([
-  "anchor-event",
-  "anchor-pr",
-  "anchor-pr-booking-support",
-  "anchor-partner-profile",
-]);
 const AUTO_LOGIN_ATTEMPT_STORAGE_KEY =
   "partner_up_wechat_auto_login_attempted_routes";
 
@@ -56,11 +50,10 @@ const clearRouteAttempted = (routeKey: string): void => {
 };
 
 const resolveAutoLoginRouteKey = (
-  routeName: string | symbol | null | undefined,
   routePath: string,
+  wechatAutoLoginPolicy: "route" | "skip" | undefined,
 ): string | null => {
-  if (typeof routeName !== "string") return null;
-  if (!AUTO_LOGIN_ROUTE_NAMES.has(routeName)) return null;
+  if (wechatAutoLoginPolicy !== "route") return null;
   return routePath;
 };
 
@@ -73,7 +66,10 @@ export const useRouteWeChatAutoLogin = () => {
     if (typeof window === "undefined") return;
     if (redirecting.value) return;
 
-    const routeKey = resolveAutoLoginRouteKey(route.name, route.path);
+    const routeKey = resolveAutoLoginRouteKey(
+      route.path,
+      route.meta.wechatAutoLoginPolicy,
+    );
     if (!routeKey) return;
 
     if (userSessionStore.isAuthenticated) {

--- a/apps/frontend/src/types/router-meta.d.ts
+++ b/apps/frontend/src/types/router-meta.d.ts
@@ -3,6 +3,7 @@ import "vue-router";
 declare module "vue-router" {
   interface RouteMeta {
     wechatSharePolicy?: "route" | "skip";
+    wechatAutoLoginPolicy?: "route" | "skip";
   }
 }
 


### PR DESCRIPTION
## Summary
- make useRouteWeChatAutoLogin depend on route meta instead of a hardcoded route list
- annotate router metadata so only /apr/:id triggers automatic OAuth and explicitly skip the Anchor event/booking-support/partner-profile routes
- document that the OAuth flow relies on WeChat-native snsapi_userinfo handling so forcePopup stays unset

## Testing
- pnpm build

Closes #113